### PR TITLE
Add WebSocket client and React hooks for real-time content updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "react": "^17.0.0"
   },
   "dependencies": {
+    "graasp-websockets": "git://github.com/graasp/graasp-websockets.git#master",
     "http-status-codes": "2.1.4",
     "immutable": "4.0.0-rc.12",
     "node-fetch": "2.6.1",
     "qs": "6.10.1",
     "react-query": "3.16.0",
-    "uuid": "8.3.2",
-    "graasp-websockets": "git://github.com/graasp/graasp-websockets.git#master"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@commitlint/cli": "12.1.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "node-fetch": "2.6.1",
     "qs": "6.10.1",
     "react-query": "3.16.0",
-    "uuid": "8.3.2"
+    "uuid": "8.3.2",
+    "graasp-websockets": "git://github.com/graasp/graasp-websockets.git#master"
   },
   "devDependencies": {
     "@commitlint/cli": "12.1.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "react": "^17.0.0"
   },
   "dependencies": {
-    "graasp-websockets": "git://github.com/graasp/graasp-websockets.git#master",
     "http-status-codes": "2.1.4",
     "immutable": "4.0.0-rc.12",
     "node-fetch": "2.6.1",
@@ -19,6 +18,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "@graasp/websockets": "git://github.com/graasp/graasp-websockets.git#master",
     "@commitlint/cli": "12.1.4",
     "@commitlint/config-conventional": "12.1.4",
     "@testing-library/jest-dom": "5.11.6",

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -75,15 +75,14 @@ export default (config: Partial<QueryClientConfig>) => {
   const hooks = configureHooks(queryClient, queryConfig);
 
   // set up websocket client and hooks given config
-  if (queryConfig.enableWebsocket) {
-    configureWebsockets(queryClient, queryConfig);
-  }
+  const ws = (queryConfig.enableWebsocket) ? { ws: configureWebsockets(queryClient, queryConfig) } : {};
 
   // returns the queryClient and relative instances
   return {
     queryClient,
     QueryClientProvider,
     hooks,
+    ...ws,
     useMutation,
     ReactQueryDevtools,
   };

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -7,7 +7,7 @@ import {
 } from './config/constants';
 import configureHooks from './hooks';
 import configureMutations from './mutations';
-import configureWebsockets from './ws';
+import configureWebSockets from './ws';
 
 export type Notifier = (e: any) => any;
 
@@ -54,8 +54,8 @@ export default (config: Partial<QueryClientConfig>) => {
       config?.WS_HOST ||
       process.env.REACT_APP_WS_HOST ||
       `${baseConfig.API_HOST.replace('http', 'ws')}/ws`,
-    // wether websocket support should be enabled
-    enableWebsocket: config?.enableWebsocket ?? true,
+    // whether websocket support should be enabled
+    enableWebsocket: config?.enableWebsocket ?? false,
     notifier: config?.notifier,
     // time until data in cache considered stale if cache not invalidated
     staleTime: STALE_TIME_MILLISECONDS,
@@ -76,7 +76,7 @@ export default (config: Partial<QueryClientConfig>) => {
 
   // set up websocket client and hooks given config
   const ws = queryConfig.enableWebsocket
-    ? { ws: configureWebsockets(queryClient, queryConfig) }
+    ? { ws: configureWebSockets(queryClient, queryConfig) }
     : {};
 
   // returns the queryClient and relative instances

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -14,6 +14,8 @@ type QueryClientConfig = {
   API_HOST: string;
   S3_FILES_HOST?: string;
   SHOW_NOTIFICATIONS?: boolean;
+  WS_HOST?: string;
+  enableWebsocket?: boolean;
   notifier?: Notifier;
 };
 
@@ -28,8 +30,7 @@ const retry = (failureCount: any, error: { name: string }) => {
 };
 
 export default (config: Partial<QueryClientConfig>) => {
-  // define config for query client
-  const queryConfig = {
+  const baseConfig = {
     API_HOST:
       config?.API_HOST ||
       process.env.REACT_APP_API_HOST ||
@@ -42,7 +43,18 @@ export default (config: Partial<QueryClientConfig>) => {
       config?.SHOW_NOTIFICATIONS ||
       process.env.REACT_APP_SHOW_NOTIFICATIONS === 'true' ||
       false,
+  }
 
+  // define config for query client
+  const queryConfig = {
+    ...baseConfig,
+    // derive WS_HOST from API_HOST if needed
+    WS_HOST:
+      config?.WS_HOST ||
+      process.env.REACT_APP_WS_HOST ||
+      `${baseConfig.API_HOST.replace('http', 'ws')}/ws`,
+    // wether websocket support should be enabled
+    enableWebsocket: config?.enableWebsocket ?? true,
     notifier: config?.notifier,
     // time until data in cache considered stale if cache not invalidated
     staleTime: STALE_TIME_MILLISECONDS,

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import configureMutations from './mutations';
 import configureHooks from './hooks';
+import configureWebsockets from './ws';
 import {
   CACHE_TIME_MILLISECONDS,
   STALE_TIME_MILLISECONDS,
@@ -72,6 +73,11 @@ export default (config: Partial<QueryClientConfig>) => {
 
   // set up hooks given config
   const hooks = configureHooks(queryClient, queryConfig);
+
+  // set up websocket client and hooks given config
+  if (queryConfig.enableWebsocket) {
+    configureWebsockets(queryClient, queryConfig);
+  }
 
   // returns the queryClient and relative instances
   return {

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,13 +1,13 @@
+import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import { QueryClient, QueryClientProvider, useMutation } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { getReasonPhrase, StatusCodes } from 'http-status-codes';
-import configureMutations from './mutations';
-import configureHooks from './hooks';
-import configureWebsockets from './ws';
 import {
   CACHE_TIME_MILLISECONDS,
   STALE_TIME_MILLISECONDS,
 } from './config/constants';
+import configureHooks from './hooks';
+import configureMutations from './mutations';
+import configureWebsockets from './ws';
 
 export type Notifier = (e: any) => any;
 
@@ -44,7 +44,7 @@ export default (config: Partial<QueryClientConfig>) => {
       config?.SHOW_NOTIFICATIONS ||
       process.env.REACT_APP_SHOW_NOTIFICATIONS === 'true' ||
       false,
-  }
+  };
 
   // define config for query client
   const queryConfig = {
@@ -75,7 +75,9 @@ export default (config: Partial<QueryClientConfig>) => {
   const hooks = configureHooks(queryClient, queryConfig);
 
   // set up websocket client and hooks given config
-  const ws = (queryConfig.enableWebsocket) ? { ws: configureWebsockets(queryClient, queryConfig) } : {};
+  const ws = queryConfig.enableWebsocket
+    ? { ws: configureWebsockets(queryClient, queryConfig) }
+    : {};
 
   // returns the queryClient and relative instances
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export type QueryClientConfig = {
   API_HOST: string;
   S3_FILES_HOST: string;
   SHOW_NOTIFICATIONS: boolean;
+  WS_HOST: string;
+  enableWebsocket: boolean;
   notifier?: Notifier;
   staleTime: number;
   cacheTime: number;

--- a/src/ws/hooks.ts
+++ b/src/ws/hooks.ts
@@ -59,8 +59,10 @@ export default (
               break;
             }
             case 'delete': {
-              mutation = current?.filter((i) => i.id !== value.id);
-              queryClient.setQueryData(parentChildrenKey, mutation);
+              if (current) {
+                mutation = current.filter((i) => i.id !== value.id);
+                queryClient.setQueryData(parentChildrenKey, mutation);
+              }
               break;
             }
           }
@@ -104,8 +106,10 @@ export default (
               break;
             }
             case 'delete': {
-              mutation = current?.filter((i) => i.id !== value.id);
-              queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+              if (current) {
+                mutation = current.filter((i) => i.id !== value.id);
+                queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+              }
               break;
             }
           }

--- a/src/ws/hooks.ts
+++ b/src/ws/hooks.ts
@@ -5,6 +5,15 @@
  * @author Alexandre CHAU
  */
 
+import {
+  WS_ENTITY_ITEM,
+  WS_ENTITY_MEMBER,
+  WS_SERVER_TYPE_UPDATE,
+  WS_UPDATE_KIND_CHILD_ITEM,
+  WS_UPDATE_KIND_SHARED_WITH,
+  WS_UPDATE_OP_CREATE,
+  WS_UPDATE_OP_DELETE,
+} from 'graasp-websockets/src/interfaces/constants';
 import { ServerMessage } from 'graasp-websockets/src/interfaces/message';
 import { List } from 'immutable';
 import { useEffect } from 'react';
@@ -16,9 +25,6 @@ import {
 } from '../config/keys';
 import { Item, UUID } from '../types';
 import { Channel, GraaspWebsocketClient } from './ws-client';
-
-const ITEM_ENTITY_TYPE = 'item';
-const MEMBER_ENTITY_TYPE = 'member';
 
 export default (
   websocketClient: GraaspWebsocketClient,
@@ -35,14 +41,14 @@ export default (
         return;
       }
 
-      const channel: Channel = { name: parentId, entity: ITEM_ENTITY_TYPE };
+      const channel: Channel = { name: parentId, entity: WS_ENTITY_ITEM };
       const parentChildrenKey = buildItemChildrenKey(parentId);
 
       const handler = (data: ServerMessage) => {
         if (
-          data.type === 'update' &&
-          data.body.kind === 'childItem' &&
-          data.body.entity === ITEM_ENTITY_TYPE
+          data.type === WS_SERVER_TYPE_UPDATE &&
+          data.body.kind === WS_UPDATE_KIND_CHILD_ITEM &&
+          data.body.entity === WS_ENTITY_ITEM
         ) {
           const current: List<Item> | undefined = queryClient.getQueryData(
             parentChildrenKey,
@@ -50,7 +56,7 @@ export default (
           const value = data.body.value;
           let mutation;
           switch (data.body.op) {
-            case 'create': {
+            case WS_UPDATE_OP_CREATE: {
               if (current && !current.find((i) => i.id === value.id)) {
                 mutation = current.push(value);
                 queryClient.setQueryData(parentChildrenKey, mutation);
@@ -58,7 +64,7 @@ export default (
               }
               break;
             }
-            case 'delete': {
+            case WS_UPDATE_OP_DELETE: {
               if (current) {
                 mutation = current.filter((i) => i.id !== value.id);
                 queryClient.setQueryData(parentChildrenKey, mutation);
@@ -83,13 +89,13 @@ export default (
         return;
       }
 
-      const channel: Channel = { name: userId, entity: MEMBER_ENTITY_TYPE };
+      const channel: Channel = { name: userId, entity: WS_ENTITY_MEMBER };
 
       const handler = (data: ServerMessage) => {
         if (
-          data.type === 'update' &&
-          data.body.kind === 'sharedWith' &&
-          data.body.entity === MEMBER_ENTITY_TYPE
+          data.type === WS_SERVER_TYPE_UPDATE &&
+          data.body.kind === WS_UPDATE_KIND_SHARED_WITH &&
+          data.body.entity === WS_ENTITY_MEMBER
         ) {
           const current: List<Item> | undefined = queryClient.getQueryData(
             SHARED_ITEMS_KEY,
@@ -97,7 +103,7 @@ export default (
           const value = data.body.value;
           let mutation;
           switch (data.body.op) {
-            case 'create': {
+            case WS_UPDATE_OP_CREATE: {
               if (current && !current.find((i) => i.id === value.id)) {
                 mutation = current.push(value);
                 queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
@@ -105,7 +111,7 @@ export default (
               }
               break;
             }
-            case 'delete': {
+            case WS_UPDATE_OP_DELETE: {
               if (current) {
                 mutation = current.filter((i) => i.id !== value.id);
                 queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);

--- a/src/ws/hooks.ts
+++ b/src/ws/hooks.ts
@@ -13,8 +13,8 @@ import {
   WS_UPDATE_KIND_SHARED_WITH,
   WS_UPDATE_OP_CREATE,
   WS_UPDATE_OP_DELETE,
-} from 'graasp-websockets/src/interfaces/constants';
-import { ServerMessage } from 'graasp-websockets/src/interfaces/message';
+} from '@graasp/websockets/src/interfaces/constants';
+import { ServerMessage } from '@graasp/websockets/src/interfaces/message';
 import { List } from 'immutable';
 import { useEffect } from 'react';
 import { QueryClient } from 'react-query';

--- a/src/ws/hooks.ts
+++ b/src/ws/hooks.ts
@@ -1,0 +1,103 @@
+/**
+ * Graasp websocket client
+ * React effect hooks to subscribe to real-time updates and mutate query client
+ * 
+ * @author Alexandre CHAU
+ */
+
+import { ServerMessage } from "graasp-websockets/src/interfaces/message";
+import { List } from "immutable";
+import { useEffect } from "react";
+import { QueryClient } from "react-query";
+import { buildItemChildrenKey, buildItemKey, SHARED_ITEMS_KEY } from "../config/keys";
+import { Item, UUID } from "../types";
+import { Channel, GraaspWebsocketClient } from "./ws-client";
+
+const ITEM_ENTITY_TYPE = "item"
+const MEMBER_ENTITY_TYPE = "member"
+
+export default (websocketClient: GraaspWebsocketClient, queryClient: QueryClient) => ({
+    /**
+     * React hook to subscribe to the children updates of the give parent item ID
+     *
+     * @param parentId The ID of the parent on which to observe children updates
+     */
+    useChildrenUpdates: (parentId: UUID) => {
+        useEffect(() => {
+            if (!parentId) {
+                return;
+            }
+
+            const channel: Channel = { name: parentId, entity: ITEM_ENTITY_TYPE };
+            const parentChildrenKey = buildItemChildrenKey(parentId);
+
+            const handler = (data: ServerMessage) => {
+                if (data.type === "update" && data.body.kind === "childItem" && data.body.entity === ITEM_ENTITY_TYPE) {
+                    const current: List<Item> | undefined = queryClient.getQueryData(parentChildrenKey);
+                    const value = data.body.value;
+                    let mutation;
+                    switch (data.body.op) {
+                        case "create": {
+                            if (current && !current.find(i => i.id === value.id)) {
+                                mutation = current.push(value);
+                                queryClient.setQueryData(parentChildrenKey, mutation);
+                                queryClient.setQueryData(buildItemKey(value.id), value);
+                            }
+                            break;
+                        }
+                        case "delete": {
+                            mutation = current?.filter(i => i.id !== value.id);
+                            queryClient.setQueryData(parentChildrenKey, mutation);
+                            break;
+                        }
+                    }
+                }
+            };
+
+            websocketClient.subscribe(channel, handler);
+
+            return function cleanup() {
+                websocketClient.unsubscribe(channel, handler);
+            };
+        }, [parentId]);
+    },
+
+    useSharedItemsUpdates: (userId: UUID) => {
+        useEffect(() => {
+            if (!userId) {
+                return;
+            }
+
+            const channel: Channel = { name: userId, entity: MEMBER_ENTITY_TYPE };
+
+            const handler = (data: ServerMessage) => {
+                if (data.type === "update" && data.body.kind === "sharedWith" && data.body.entity === MEMBER_ENTITY_TYPE) {
+                    const current: List<Item> | undefined = queryClient.getQueryData(SHARED_ITEMS_KEY);
+                    const value = data.body.value;
+                    let mutation;
+                    switch (data.body.op) {
+                        case "create": {
+                            if (current && !current.find(i => i.id === value.id)) {
+                                mutation = current.push(value);
+                                queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+                                queryClient.setQueryData(buildItemKey(value.id), value);
+                            }
+                            break;
+                        }
+                        case "delete": {
+                            mutation = current?.filter(i => i.id !== value.id);
+                            queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+                            break;
+                        }
+                    }
+                }
+            };
+
+            websocketClient.subscribe(channel, handler);
+
+            return function cleanup() {
+                websocketClient.unsubscribe(channel, handler);
+            }
+        }, [userId]);
+    },
+});

--- a/src/ws/hooks.ts
+++ b/src/ws/hooks.ts
@@ -1,103 +1,122 @@
 /**
  * Graasp websocket client
  * React effect hooks to subscribe to real-time updates and mutate query client
- * 
+ *
  * @author Alexandre CHAU
  */
 
-import { ServerMessage } from "graasp-websockets/src/interfaces/message";
-import { List } from "immutable";
-import { useEffect } from "react";
-import { QueryClient } from "react-query";
-import { buildItemChildrenKey, buildItemKey, SHARED_ITEMS_KEY } from "../config/keys";
-import { Item, UUID } from "../types";
-import { Channel, GraaspWebsocketClient } from "./ws-client";
+import { ServerMessage } from 'graasp-websockets/src/interfaces/message';
+import { List } from 'immutable';
+import { useEffect } from 'react';
+import { QueryClient } from 'react-query';
+import {
+  buildItemChildrenKey,
+  buildItemKey,
+  SHARED_ITEMS_KEY,
+} from '../config/keys';
+import { Item, UUID } from '../types';
+import { Channel, GraaspWebsocketClient } from './ws-client';
 
-const ITEM_ENTITY_TYPE = "item"
-const MEMBER_ENTITY_TYPE = "member"
+const ITEM_ENTITY_TYPE = 'item';
+const MEMBER_ENTITY_TYPE = 'member';
 
-export default (websocketClient: GraaspWebsocketClient, queryClient: QueryClient) => ({
-    /**
-     * React hook to subscribe to the children updates of the give parent item ID
-     *
-     * @param parentId The ID of the parent on which to observe children updates
-     */
-    useChildrenUpdates: (parentId: UUID) => {
-        useEffect(() => {
-            if (!parentId) {
-                return;
+export default (
+  websocketClient: GraaspWebsocketClient,
+  queryClient: QueryClient,
+) => ({
+  /**
+   * React hook to subscribe to the children updates of the give parent item ID
+   *
+   * @param parentId The ID of the parent on which to observe children updates
+   */
+  useChildrenUpdates: (parentId: UUID) => {
+    useEffect(() => {
+      if (!parentId) {
+        return;
+      }
+
+      const channel: Channel = { name: parentId, entity: ITEM_ENTITY_TYPE };
+      const parentChildrenKey = buildItemChildrenKey(parentId);
+
+      const handler = (data: ServerMessage) => {
+        if (
+          data.type === 'update' &&
+          data.body.kind === 'childItem' &&
+          data.body.entity === ITEM_ENTITY_TYPE
+        ) {
+          const current: List<Item> | undefined = queryClient.getQueryData(
+            parentChildrenKey,
+          );
+          const value = data.body.value;
+          let mutation;
+          switch (data.body.op) {
+            case 'create': {
+              if (current && !current.find((i) => i.id === value.id)) {
+                mutation = current.push(value);
+                queryClient.setQueryData(parentChildrenKey, mutation);
+                queryClient.setQueryData(buildItemKey(value.id), value);
+              }
+              break;
             }
-
-            const channel: Channel = { name: parentId, entity: ITEM_ENTITY_TYPE };
-            const parentChildrenKey = buildItemChildrenKey(parentId);
-
-            const handler = (data: ServerMessage) => {
-                if (data.type === "update" && data.body.kind === "childItem" && data.body.entity === ITEM_ENTITY_TYPE) {
-                    const current: List<Item> | undefined = queryClient.getQueryData(parentChildrenKey);
-                    const value = data.body.value;
-                    let mutation;
-                    switch (data.body.op) {
-                        case "create": {
-                            if (current && !current.find(i => i.id === value.id)) {
-                                mutation = current.push(value);
-                                queryClient.setQueryData(parentChildrenKey, mutation);
-                                queryClient.setQueryData(buildItemKey(value.id), value);
-                            }
-                            break;
-                        }
-                        case "delete": {
-                            mutation = current?.filter(i => i.id !== value.id);
-                            queryClient.setQueryData(parentChildrenKey, mutation);
-                            break;
-                        }
-                    }
-                }
-            };
-
-            websocketClient.subscribe(channel, handler);
-
-            return function cleanup() {
-                websocketClient.unsubscribe(channel, handler);
-            };
-        }, [parentId]);
-    },
-
-    useSharedItemsUpdates: (userId: UUID) => {
-        useEffect(() => {
-            if (!userId) {
-                return;
+            case 'delete': {
+              mutation = current?.filter((i) => i.id !== value.id);
+              queryClient.setQueryData(parentChildrenKey, mutation);
+              break;
             }
+          }
+        }
+      };
 
-            const channel: Channel = { name: userId, entity: MEMBER_ENTITY_TYPE };
+      websocketClient.subscribe(channel, handler);
 
-            const handler = (data: ServerMessage) => {
-                if (data.type === "update" && data.body.kind === "sharedWith" && data.body.entity === MEMBER_ENTITY_TYPE) {
-                    const current: List<Item> | undefined = queryClient.getQueryData(SHARED_ITEMS_KEY);
-                    const value = data.body.value;
-                    let mutation;
-                    switch (data.body.op) {
-                        case "create": {
-                            if (current && !current.find(i => i.id === value.id)) {
-                                mutation = current.push(value);
-                                queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
-                                queryClient.setQueryData(buildItemKey(value.id), value);
-                            }
-                            break;
-                        }
-                        case "delete": {
-                            mutation = current?.filter(i => i.id !== value.id);
-                            queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
-                            break;
-                        }
-                    }
-                }
-            };
+      return function cleanup() {
+        websocketClient.unsubscribe(channel, handler);
+      };
+    }, [parentId]);
+  },
 
-            websocketClient.subscribe(channel, handler);
+  useSharedItemsUpdates: (userId: UUID) => {
+    useEffect(() => {
+      if (!userId) {
+        return;
+      }
 
-            return function cleanup() {
-                websocketClient.unsubscribe(channel, handler);
+      const channel: Channel = { name: userId, entity: MEMBER_ENTITY_TYPE };
+
+      const handler = (data: ServerMessage) => {
+        if (
+          data.type === 'update' &&
+          data.body.kind === 'sharedWith' &&
+          data.body.entity === MEMBER_ENTITY_TYPE
+        ) {
+          const current: List<Item> | undefined = queryClient.getQueryData(
+            SHARED_ITEMS_KEY,
+          );
+          const value = data.body.value;
+          let mutation;
+          switch (data.body.op) {
+            case 'create': {
+              if (current && !current.find((i) => i.id === value.id)) {
+                mutation = current.push(value);
+                queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+                queryClient.setQueryData(buildItemKey(value.id), value);
+              }
+              break;
             }
-        }, [userId]);
-    },
+            case 'delete': {
+              mutation = current?.filter((i) => i.id !== value.id);
+              queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
+              break;
+            }
+          }
+        }
+      };
+
+      websocketClient.subscribe(channel, handler);
+
+      return function cleanup() {
+        websocketClient.unsubscribe(channel, handler);
+      };
+    }, [userId]);
+  },
 });

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -1,23 +1,20 @@
 /**
  * Graasp websocket client top-level file
  * Entry point to use the Graasp WebSocket client in front-end applications
- * 
+ *
  * @author Alexandre CHAU
  */
 
-import { QueryClient } from "react-query";
-import { QueryClientConfig } from "../types";
-import configureWebsocketHooks from "./hooks";
-import { configureWebsocketClient } from "./ws-client";
+import { QueryClient } from 'react-query';
+import { QueryClientConfig } from '../types';
+import configureWebsocketHooks from './hooks';
+import { configureWebsocketClient } from './ws-client';
 
 // to be called by the main query client configurator
-export default (
-    queryClient: QueryClient,
-    queryConfig: QueryClientConfig,
-) => {
-    const websocketClient = configureWebsocketClient(queryConfig);
+export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
+  const websocketClient = configureWebsocketClient(queryConfig);
 
-    return {
-        hooks: configureWebsocketHooks(websocketClient, queryClient),
-    };
+  return {
+    hooks: configureWebsocketHooks(websocketClient, queryClient),
+  };
 };

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -1,11 +1,23 @@
+/**
+ * Graasp websocket client top-level file
+ * Entry point to use the Graasp WebSocket client in front-end applications
+ * 
+ * @author Alexandre CHAU
+ */
+
 import { QueryClient } from "react-query";
 import { QueryClientConfig } from "../types";
+import configureWebsocketHooks from "./hooks";
+import { configureWebsocketClient } from "./ws-client";
 
-const configureWebsockets = (
+// to be called by the main query client configurator
+export default (
     queryClient: QueryClient,
     queryConfig: QueryClientConfig,
-) => ({
+) => {
+    const websocketClient = configureWebsocketClient(queryConfig);
 
-});
-
-export default configureWebsockets;
+    return {
+        hooks: configureWebsocketHooks(websocketClient, queryClient),
+    };
+};

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "react-query";
+import { QueryClientConfig } from "../types";
+
+const configureWebsockets = (
+    queryClient: QueryClient,
+    queryConfig: QueryClientConfig,
+) => ({
+
+});
+
+export default configureWebsockets;

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -2,16 +2,19 @@
  * Graasp websocket client
  * Provides front-end integration for real-time updates using WebSocket
  * Implements the client protocol from https://github.com/graasp/graasp-websockets
- * 
+ *
  * @author Alexandre CHAU
  */
 
-import { ClientMessage, ServerMessage } from "graasp-websockets/src/interfaces/message";
-import { QueryClientConfig } from "../types";
+import {
+    ClientMessage,
+    ServerMessage
+} from 'graasp-websockets/src/interfaces/message';
+import { QueryClientConfig } from '../types';
 
 export type Channel = {
-    entity: "item" | "member";
-    name: string,
+  entity: 'item' | 'member';
+  name: string;
 };
 type UpdateHandlerFn = (data: ServerMessage) => void;
 
@@ -19,10 +22,14 @@ type UpdateHandlerFn = (data: ServerMessage) => void;
  * Helper to remove the first element in an array that
  * matches the provided value IN PLACE
  */
-function arrayRemoveFirstEqual<T>(array: Array<T>, value: T, eqFn = (a: T, b: T) => a === b) {
-    const pos = array.findIndex(v => eqFn(v, value));
-    const removed = array.splice(pos, 1);
-    return (removed.length > 0);
+function arrayRemoveFirstEqual<T>(
+  array: Array<T>,
+  value: T,
+  eqFn = (a: T, b: T) => a === b,
+) {
+  const pos = array.findIndex((v) => eqFn(v, value));
+  const removed = array.splice(pos, 1);
+  return removed.length > 0;
 }
 
 /**
@@ -30,12 +37,12 @@ function arrayRemoveFirstEqual<T>(array: Array<T>, value: T, eqFn = (a: T, b: T)
  * if the map entry does not exist
  */
 function addToMappedArray<S, T>(map: Map<S, Array<T>>, key: S, value: T) {
-    const array = map.get(key);
-    if (array === undefined) {
-        map.set(key, [value]);
-    } else {
-        array.push(value);
-    }
+  const array = map.get(key);
+  if (array === undefined) {
+    map.set(key, [value]);
+  } else {
+    array.push(value);
+  }
 }
 
 /**
@@ -43,211 +50,227 @@ function addToMappedArray<S, T>(map: Map<S, Array<T>>, key: S, value: T) {
  * (deep equality) to serve as map keys
  */
 function buildChannelKey(channel: Channel): string {
-    // ensure serialized key is always identical (properties + order)
-    const rebuiltChannel: Channel = { name: channel.name, entity: channel.entity };
-    return JSON.stringify(rebuiltChannel);
-};
+  // ensure serialized key is always identical (properties + order)
+  const rebuiltChannel: Channel = {
+    name: channel.name,
+    entity: channel.entity,
+  };
+  return JSON.stringify(rebuiltChannel);
+}
 function keyToChannel(key: string): Channel {
-    return JSON.parse(key);
-};
+  return JSON.parse(key);
+}
 
 /**
  * Websocket client for the graasp-websockets protocol
  */
 export interface GraaspWebsocketClient {
-    /**
-     * Subscribe a handler to a given channel
-     * @param channel Channel to which to subscribe to
-     * @param handler Handler function to register
-     */
-    subscribe(channel: Channel, handler: UpdateHandlerFn): void
+  /**
+   * Subscribe a handler to a given channel
+   * @param channel Channel to which to subscribe to
+   * @param handler Handler function to register
+   */
+  subscribe(channel: Channel, handler: UpdateHandlerFn): void;
 
-    /**
-     * Unsubscribe a handler from a channel, THE HANDLER MUST === THE ONE PASSED TO SUBSCRIBE
-     * @param channel Channel from wihch to unsubscribe the provided handler from
-     * @param handler Handler function to unregster, MUST BE EQUAL (===) TO PREVIOUSLY REGISTERED HANDLE WITH @see subscribe !
-     */
-    unsubscribe(channel: Channel, handler: UpdateHandlerFn): void
+  /**
+   * Unsubscribe a handler from a channel, THE HANDLER MUST === THE ONE PASSED TO SUBSCRIBE
+   * @param channel Channel from wihch to unsubscribe the provided handler from
+   * @param handler Handler function to unregster, MUST BE EQUAL (===) TO PREVIOUSLY REGISTERED HANDLE WITH @see subscribe !
+   */
+  unsubscribe(channel: Channel, handler: UpdateHandlerFn): void;
 }
 
-export const configureWebsocketClient = (config: QueryClientConfig): GraaspWebsocketClient => {
-    // native client WebSocket instance
-    const ws = new WebSocket(config.WS_HOST);
+export const configureWebsocketClient = (
+  config: QueryClientConfig,
+): GraaspWebsocketClient => {
+  // native client WebSocket instance
+  const ws = new WebSocket(config.WS_HOST);
 
-    // TODO: heartbeat
+  // TODO: heartbeat
 
-    // (de-)serializer instance
-    const serdes = {
-        serialize: (msg: ClientMessage): string => JSON.stringify(msg),
-        parse: (data: string): ServerMessage => JSON.parse(data),
-    };
+  // (de-)serializer instance
+  const serdes = {
+    serialize: (msg: ClientMessage): string => JSON.stringify(msg),
+    parse: (data: string): ServerMessage => JSON.parse(data),
+  };
 
-    const send = (request: ClientMessage) => {
-        if (ws.readyState === ws.OPEN) {
-            ws.send(serdes.serialize(request));
+  const send = (request: ClientMessage) => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(serdes.serialize(request));
+    }
+  };
+
+  const sendSubscribeRequest = (channel: Channel) => {
+    send({
+      realm: 'notif',
+      action: 'subscribe',
+      entity: channel.entity,
+      channel: channel.name,
+    });
+  };
+
+  const sendUnsubscribeRequest = (channel: Channel) => {
+    send({
+      realm: 'notif',
+      action: 'unsubscribe',
+      channel: channel.name,
+    });
+  };
+
+  const subscriptions = {
+    early: new Map<string, Array<UpdateHandlerFn>>(),
+    waitingAck: new Map<string, Array<UpdateHandlerFn>>(),
+    current: new Map<string, Array<UpdateHandlerFn>>(),
+    info: new Array<UpdateHandlerFn>(),
+
+    add: (channel: Channel | 'info', handler: UpdateHandlerFn): boolean => {
+      if (channel === 'info') {
+        // if subscribed to info, no ack to wait for
+        subscriptions.info.push(handler);
+        return false;
+      } else {
+        const channelKey = buildChannelKey(channel);
+        const maybeCurrent = subscriptions.current.get(channelKey);
+        if (maybeCurrent !== undefined && maybeCurrent.length > 0) {
+          // if already subscribed, don't subscribe again, simply register handler in current
+          addToMappedArray(subscriptions.current, channelKey, handler);
+          return false;
+        } else {
+          // if WS not ready, add to early, otherwise add to waiting ack
+          const map =
+            ws.readyState === ws.OPEN
+              ? subscriptions.waitingAck
+              : subscriptions.early;
+          // create queue if doesn't exist for this channel, otherwise push to it
+          addToMappedArray(map, channelKey, handler);
+          return true;
         }
-    };
+      }
+    },
 
-    const sendSubscribeRequest = (channel: Channel) => {
-        send({
-            realm: "notif",
-            action: "subscribe",
-            entity: channel.entity,
-            channel: channel.name,
-        });
-    };
-
-    const sendUnsubscribeRequest = (channel: Channel) => {
-        send({
-            realm: "notif",
-            action: "unsubscribe",
-            channel: channel.name,
-        });
-    };
-
-    const subscriptions = {
-        early: new Map<string, Array<UpdateHandlerFn>>(),
-        waitingAck: new Map<string, Array<UpdateHandlerFn>>(),
-        current: new Map<string, Array<UpdateHandlerFn>>(),
-        info: new Array<UpdateHandlerFn>(),
-
-        add: (channel: Channel | "info", handler: UpdateHandlerFn): boolean => {
-            if (channel === "info") {
-                // if subscribed to info, no ack to wait for
-                subscriptions.info.push(handler);
-                return false;
-            } else {
-                const channelKey = buildChannelKey(channel);
-                const maybeCurrent = subscriptions.current.get(channelKey);
-                if (maybeCurrent !== undefined && maybeCurrent.length > 0) {
-                    // if already subscribed, don't subscribe again, simply register handler in current
-                    addToMappedArray(subscriptions.current, channelKey, handler);
-                    return false;
-                } else {
-                    // if WS not ready, add to early, otherwise add to waiting ack
-                    const map = (ws.readyState === ws.OPEN) ? subscriptions.waitingAck : subscriptions.early;
-                    // create queue if doesn't exist for this channel, otherwise push to it
-                    addToMappedArray(map, channelKey, handler);
-                    return true;
-                }
-            }
-        },
-
-        remove: (channel: Channel | "info", handler: UpdateHandlerFn): boolean => {
-            if (channel === "info") {
-                arrayRemoveFirstEqual(subscriptions.info, handler);
-                return false;
-            } else {
-                // helper to remove from a subscription map
-                const _remove = (map: Map<string, Array<UpdateHandlerFn>>, channelKey: string, handler: UpdateHandlerFn): boolean => {
-                    const queue = map.get(channelKey);
-                    if (queue !== undefined) {
-                        return arrayRemoveFirstEqual(queue, handler);
-                    } else {
-                        return false;
-                    }
-                };
-                // helper to cleanup mapped array if it is empty
-                const _cleanup = (map: Map<string, Array<UpdateHandlerFn>>, channelKey: string): boolean => {
-                    const isNowEmpty = (map.get(channelKey)?.length === 0);
-                    if (isNowEmpty) {
-                        // cleanup array
-                        map.delete(channelKey);
-                    }
-                    return isNowEmpty;
-                }
-
-                const channelKey = buildChannelKey(channel);
-                // find first map from which to remove from
-                if (_remove(subscriptions.early, channelKey, handler)) {
-                    // no need to send unsubscribe if still in early
-                    return false;
-                } else if (_remove(subscriptions.waitingAck, channelKey, handler)) {
-                    // if in waitingAck must send unsubscribe if just got emptied
-                    return _cleanup(subscriptions.waitingAck, channelKey);
-                } else if (_remove(subscriptions.current, channelKey, handler)) {
-                    // if in current must send unsubscribe if just got emptied
-                    return _cleanup(subscriptions.current, channelKey);
-                } else {
-                    return false;
-                }
-            }
-        },
-
-        ack: (channel: Channel) => {
-            const channelKey = buildChannelKey(channel);
-            // move all pending handlers from waitingAck to current
-            const handlers = subscriptions.waitingAck.get(channelKey);
-            handlers?.forEach(handler => {
-                addToMappedArray(subscriptions.current, channelKey, handler);
-            });
-            subscriptions.waitingAck.delete(channelKey);
-        },
-    };
-
-    ws.addEventListener('open', () => {
-        console.debug('Websocket connection opened');
-
-        // send early subscriptions
-        subscriptions.early.forEach((queue, channelKey) => {
-            const channel = keyToChannel(channelKey);
-            // move all handlers and send only one subscribtion per channel
-            queue.forEach(handler => {
-                // move handler to waitingAck (guaranteed now since ws.readyState === OPEN)
-                subscriptions.add(channel, handler);
-            });
-            sendSubscribeRequest(channel);
-        });
-        subscriptions.early.clear();
-    });
-
-    ws.addEventListener('message', event => {
-        const update = serdes.parse(event.data);
-
-        switch (update.type) {
-            case "info": {
-                subscriptions.info.forEach(fn => fn(update));
-                break;
-            };
-
-            case "response": {
-                if (update.status === "success") {
-                    const req = update.request;
-                    if (req?.action === "subscribe") {
-                        // when ack, move all from waiting acks to current
-                        subscriptions.ack({ name: req?.channel, entity: req?.entity });
-                    }
-                }
-                else {
-                    console.debug(`WS error response: ${update.error?.name} ${update.error?.message}`);
-                }
-                break;
-            };
-
-            case "update": {
-                // send update to all handlers of this channel
-                const channel = { name: update.channel, entity: update.body.entity };
-                const channelKey = buildChannelKey(channel);
-                const handlers = subscriptions.current.get(channelKey);
-                handlers?.forEach(fn => fn(update));
-                break;
-            };
-
-            default:
-                console.debug('Unknown WS message');
+    remove: (channel: Channel | 'info', handler: UpdateHandlerFn): boolean => {
+      if (channel === 'info') {
+        arrayRemoveFirstEqual(subscriptions.info, handler);
+        return false;
+      } else {
+        // helper to remove from a subscription map
+        const _remove = (
+          map: Map<string, Array<UpdateHandlerFn>>,
+          channelKey: string,
+          handler: UpdateHandlerFn,
+        ): boolean => {
+          const queue = map.get(channelKey);
+          if (queue !== undefined) {
+            return arrayRemoveFirstEqual(queue, handler);
+          } else {
+            return false;
+          }
         };
-    });
+        // helper to cleanup mapped array if it is empty
+        const _cleanup = (
+          map: Map<string, Array<UpdateHandlerFn>>,
+          channelKey: string,
+        ): boolean => {
+          const isNowEmpty = map.get(channelKey)?.length === 0;
+          if (isNowEmpty) {
+            // cleanup array
+            map.delete(channelKey);
+          }
+          return isNowEmpty;
+        };
 
-    return {
-        subscribe: (channel: Channel | "info", handler: UpdateHandlerFn) => {
-            if (subscriptions.add(channel, handler) && channel !== "info") {
-                sendSubscribeRequest(channel);
-            };
-        },
-        unsubscribe: (channel: Channel | "info", handler: UpdateHandlerFn) => {
-            if (subscriptions.remove(channel, handler) && channel !== "info") {
-                sendUnsubscribeRequest(channel);
-            }
-        },
-    };
+        const channelKey = buildChannelKey(channel);
+        // find first map from which to remove from
+        if (_remove(subscriptions.early, channelKey, handler)) {
+          // no need to send unsubscribe if still in early
+          return false;
+        } else if (_remove(subscriptions.waitingAck, channelKey, handler)) {
+          // if in waitingAck must send unsubscribe if just got emptied
+          return _cleanup(subscriptions.waitingAck, channelKey);
+        } else if (_remove(subscriptions.current, channelKey, handler)) {
+          // if in current must send unsubscribe if just got emptied
+          return _cleanup(subscriptions.current, channelKey);
+        } else {
+          return false;
+        }
+      }
+    },
+
+    ack: (channel: Channel) => {
+      const channelKey = buildChannelKey(channel);
+      // move all pending handlers from waitingAck to current
+      const handlers = subscriptions.waitingAck.get(channelKey);
+      handlers?.forEach((handler) => {
+        addToMappedArray(subscriptions.current, channelKey, handler);
+      });
+      subscriptions.waitingAck.delete(channelKey);
+    },
+  };
+
+  ws.addEventListener('open', () => {
+    console.debug('Websocket connection opened');
+
+    // send early subscriptions
+    subscriptions.early.forEach((queue, channelKey) => {
+      const channel = keyToChannel(channelKey);
+      // move all handlers and send only one subscribtion per channel
+      queue.forEach((handler) => {
+        // move handler to waitingAck (guaranteed now since ws.readyState === OPEN)
+        subscriptions.add(channel, handler);
+      });
+      sendSubscribeRequest(channel);
+    });
+    subscriptions.early.clear();
+  });
+
+  ws.addEventListener('message', (event) => {
+    const update = serdes.parse(event.data);
+
+    switch (update.type) {
+      case 'info': {
+        subscriptions.info.forEach((fn) => fn(update));
+        break;
+      }
+
+      case 'response': {
+        if (update.status === 'success') {
+          const req = update.request;
+          if (req?.action === 'subscribe') {
+            // when ack, move all from waiting acks to current
+            subscriptions.ack({ name: req?.channel, entity: req?.entity });
+          }
+        } else {
+          console.debug(
+            `WS error response: ${update.error?.name} ${update.error?.message}`,
+          );
+        }
+        break;
+      }
+
+      case 'update': {
+        // send update to all handlers of this channel
+        const channel = { name: update.channel, entity: update.body.entity };
+        const channelKey = buildChannelKey(channel);
+        const handlers = subscriptions.current.get(channelKey);
+        handlers?.forEach((fn) => fn(update));
+        break;
+      }
+
+      default:
+        console.debug('Unknown WS message');
+    }
+  });
+
+  return {
+    subscribe: (channel: Channel | 'info', handler: UpdateHandlerFn) => {
+      if (subscriptions.add(channel, handler) && channel !== 'info') {
+        sendSubscribeRequest(channel);
+      }
+    },
+    unsubscribe: (channel: Channel | 'info', handler: UpdateHandlerFn) => {
+      if (subscriptions.remove(channel, handler) && channel !== 'info') {
+        sendUnsubscribeRequest(channel);
+      }
+    },
+  };
 };

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -43,7 +43,9 @@ function addToMappedArray<S, T>(map: Map<S, Array<T>>, key: S, value: T) {
  * (deep equality) to serve as map keys
  */
 function buildChannelKey(channel: Channel): string {
-    return JSON.stringify(channel);
+    // ensure serialized key is always identical (properties + order)
+    const rebuiltChannel: Channel = { name: channel.name, entity: channel.entity };
+    return JSON.stringify(rebuiltChannel);
 };
 function keyToChannel(key: string): Channel {
     return JSON.parse(key);

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -1,0 +1,173 @@
+/**
+ * Graasp websocket client
+ * Provides front-end integration for real-time updates using WebSocket
+ * Implements the client protocol from https://github.com/graasp/graasp-websockets
+ * 
+ * @author Alexandre CHAU
+ */
+
+import { ClientMessage, ServerMessage } from "graasp-websockets/src/interfaces/message";
+import { QueryClientConfig } from "../types";
+
+type Channel = {
+    entity: "item" | "member";
+    name: string,
+};
+type UpdateHandlerFn = (data: ServerMessage) => void;
+
+/**
+ * Helper to remove the first element in an array that
+ * matches the provided value IN PLACE
+ */
+function arrayRemoveFirst<T>(array: Array<T>, value: T, eqFn = (a: T, b: T) => a === b) {
+    const pos = array.findIndex(v => eqFn(v, value));
+    array.splice(pos, 1);
+}
+
+export const configureWebsocketClient = (config: QueryClientConfig) => {
+    // native client WebSocket instance
+    const ws = new WebSocket(config.WS_HOST);
+
+    // (de-)serializer instance
+    const serdes = {
+        serialize: (msg: ClientMessage): string => JSON.stringify(msg),
+        parse: (data: string): ServerMessage => JSON.parse(data),
+    };
+
+    const send = (request: ClientMessage) => {
+        if (ws.readyState === ws.OPEN) {
+            ws.send(serdes.serialize(request));
+        }
+    };
+
+    const sendSubscribeRequest = (channel: Channel) => {
+        send({
+            realm: "notif",
+            action: "subscribe",
+            entity: channel.entity,
+            channel: channel.name,
+        });
+    };
+
+    const sendUnsubscribeRequest = (channel: Channel) => {
+        send({
+            realm: "notif",
+            action: "unsubscribe",
+            channel: channel.name,
+        });
+    };
+
+    const subscriptions = {
+        early: new Map<Channel, Array<UpdateHandlerFn>>(),
+        waitingAck: new Map<Channel, Array<UpdateHandlerFn>>(),
+        current: new Map<Channel, Array<UpdateHandlerFn>>(),
+        info: new Array<UpdateHandlerFn>(),
+
+        add: (channel: Channel | "info", handler: UpdateHandlerFn) => {
+            if (channel === "info") {
+                // if subscribed to info, no ack to wait for
+                subscriptions.info.push(handler);
+            } else {
+                // if WS not ready, add to early, otherwise add to waiting ack
+                const map = (ws.readyState === ws.OPEN) ? subscriptions.waitingAck : subscriptions.early;
+                // create queue if doesn't exist for this channel, otherwise push to it
+                const queue = map.get(channel);
+                if (queue === undefined) {
+                    map.set(channel, [handler]);
+                } else {
+                    queue.push(handler);
+                }
+            }
+        },
+
+        remove: (channel: Channel | "info", handler: UpdateHandlerFn) => {
+            if (channel === "info") {
+                arrayRemoveFirst(subscriptions.info, handler);
+            } else {
+                // helper to remove from a subscription map
+                const _remove = (map: Map<Channel, Array<UpdateHandlerFn>>, channel: Channel, handler: UpdateHandlerFn) => {
+                    const queue = map.get(channel);
+                    if (queue !== undefined) {
+                        arrayRemoveFirst(queue, handler);
+                    }
+                };
+
+                // remove from all maps
+                _remove(subscriptions.early, channel, handler);
+                _remove(subscriptions.waitingAck, channel, handler);
+                _remove(subscriptions.current, channel, handler);
+            }
+        },
+
+        ackOne: (channel: Channel) => {
+            // move first handler from waitingAck to current
+            const handler = subscriptions.waitingAck.get(channel)?.shift();
+            if (handler) {
+                const current = subscriptions.current.get(channel);
+                if (channel === undefined) {
+                    subscriptions.current.set(channel, [handler]);
+                } else {
+                    current?.push(handler);
+                }
+             }
+        },
+    };
+
+    ws.addEventListener('open', () => {
+        console.debug('Websocket connection opened');
+
+        // send all early subscriptions
+        subscriptions.early.forEach((queue, channel) => {
+            queue.forEach(handler => {
+                // move handler to waitingAck (guaranteed now since ws.readyState === OPEN)
+                subscriptions.add(channel, handler);
+                sendSubscribeRequest(channel);
+            });
+        });
+        subscriptions.early.clear();
+    });
+
+    ws.addEventListener('message', event => {
+        const update = serdes.parse(event.data);
+
+        switch (update.type) {
+            case "info": {
+                subscriptions.info.forEach(fn => fn(update));
+                break;
+            };
+
+            case "response": {
+                if (update.status === "success") {
+                    const req = update.request;
+                    if (req?.action === "subscribe") {
+                        subscriptions.ackOne({ name: req?.channel, entity: req?.entity });
+                    }
+                }
+                else {
+                    console.debug(`WS error response: ${update.error?.name} ${update.error?.message}`);
+                }
+                break;
+            };
+
+            case "update": {
+                const handlers = subscriptions.current.get({ name: update.channel, entity: update.body.entity });
+                handlers?.forEach(fn => fn(update));
+                break;
+            };
+
+            default:
+                console.debug('Unknown WS message');
+        };
+    });
+
+    return {
+        subscribe: (channel: Channel | "info", handler: UpdateHandlerFn) => {
+            subscriptions.add(channel, handler);
+            if (channel !== "info") { sendSubscribeRequest(channel); };
+        },
+        unsubscribe: (channel: Channel | "info", handler: UpdateHandlerFn) => {
+            subscriptions.remove(channel, handler);
+            if (channel !== "info") { sendUnsubscribeRequest(channel); };
+        },
+    };
+};

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-    ClientMessage,
-    ServerMessage
+  ClientMessage,
+  ServerMessage,
 } from 'graasp-websockets/src/interfaces/message';
 import { QueryClientConfig } from '../types';
 
@@ -28,6 +28,9 @@ function arrayRemoveFirstEqual<T>(
   eqFn = (a: T, b: T) => a === b,
 ) {
   const pos = array.findIndex((v) => eqFn(v, value));
+  if (pos === -1) {
+    return false;
+  }
   const removed = array.splice(pos, 1);
   return removed.length > 0;
 }

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -15,11 +15,11 @@ import {
   WS_SERVER_TYPE_INFO,
   WS_SERVER_TYPE_RESPONSE,
   WS_SERVER_TYPE_UPDATE,
-} from 'graasp-websockets/src/interfaces/constants';
+} from '@graasp/websockets/src/interfaces/constants';
 import {
   ClientMessage,
   ServerMessage,
-} from 'graasp-websockets/src/interfaces/message';
+} from '@graasp/websockets/src/interfaces/message';
 import { QueryClientConfig } from '../types';
 
 export type Channel = {

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -9,7 +9,7 @@
 import { ClientMessage, ServerMessage } from "graasp-websockets/src/interfaces/message";
 import { QueryClientConfig } from "../types";
 
-type Channel = {
+export type Channel = {
     entity: "item" | "member";
     name: string,
 };
@@ -38,7 +38,26 @@ function addToMappedArray<S, T>(map: Map<S, Array<T>>, key: S, value: T) {
     }
 }
 
-export const configureWebsocketClient = (config: QueryClientConfig) => {
+/**
+ * Websocket client for the graasp-websockets protocol
+ */
+export interface GraaspWebsocketClient {
+    /**
+     * Subscribe a handler to a given channel
+     * @param channel Channel to which to subscribe to
+     * @param handler Handler function to register
+     */
+    subscribe(channel: Channel, handler: UpdateHandlerFn): void
+
+    /**
+     * Unsubscribe a handler from a channel, THE HANDLER MUST === THE ONE PASSED TO SUBSCRIBE
+     * @param channel Channel from wihch to unsubscribe the provided handler from
+     * @param handler Handler function to unregster, MUST BE EQUAL (===) TO PREVIOUSLY REGISTERED HANDLE WITH @see subscribe !
+     */
+    unsubscribe(channel: Channel, handler: UpdateHandlerFn): void
+}
+
+export const configureWebsocketClient = (config: QueryClientConfig): GraaspWebsocketClient => {
     // native client WebSocket instance
     const ws = new WebSocket(config.WS_HOST);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,6 +1120,13 @@
   dependencies:
     chalk "^4.0.0"
 
+"@fastify/ajv-compiler@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz#5ce80b1fc8bebffc8c5ba428d5e392d0f9ed10a1"
+  integrity sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==
+  dependencies:
+    ajv "^6.12.6"
+
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
@@ -1617,6 +1624,11 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abstract-logging@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-2.0.1.tgz#6b0c371df212db7129b57d2e7fcf282b8bf1c839"
+  integrity sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==
+
 acorn@^7.1.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -1626,6 +1638,26 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
+
+"ajv-latest@npm:ajv@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720"
+  integrity sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.6:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 alphanum-sort@^1.0.0:
   version "1.0.2"
@@ -1660,6 +1692,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1756,6 +1793,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 autoprefixer@^9.7.3:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -1768,6 +1810,16 @@ autoprefixer@^9.7.3:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+avvio@^7.1.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/avvio/-/avvio-7.2.2.tgz#58e00e7968870026cd7b7d4f689d596db629e251"
+  integrity sha512-XW2CMCmZaCmCCsIaJaLKxAzPwF37fXi1KGxNOvedOpeisLdmxZnblGc3hpHWYnlP+KOUxZsazh43WXNHgXpbqw==
+  dependencies:
+    archy "^1.0.0"
+    debug "^4.0.0"
+    fastq "^1.6.1"
+    queue-microtask "^1.1.2"
 
 axe-core@^4.0.2:
   version "4.2.2"
@@ -2060,6 +2112,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
@@ -2351,6 +2408,11 @@ convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 core-js-compat@^3.14.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.15.0.tgz#e14a371123db9d1c5b41206d3f420643d238b8fa"
@@ -2637,7 +2699,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2673,6 +2735,11 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+denque@^1.1.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -2751,6 +2818,11 @@ dot-prop@^5.1.0, dot-prop@^5.2.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+dotenv@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
 
 dotgitignore@^2.1.0:
   version "2.1.0"
@@ -3032,10 +3104,97 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
+
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-json-stringify@^2.5.2:
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.7.6.tgz#c7c92f613f90427a809fe66b2d181ee23e0f0749"
+  integrity sha512-ezem8qpAgpad6tXeUhK0aSCS8Fi2vjxTorI9i5M+xrq6UUbTl7/bBTxL1SjRI2zy+qpPkdD4+UblUCQdxRpvIg==
+  dependencies:
+    ajv "^6.11.0"
+    deepmerge "^4.2.2"
+    rfdc "^1.2.0"
+    string-similarity "^4.0.1"
+
+fast-redact@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.0.1.tgz#d6015b971e933d03529b01333ba7f22c29961e92"
+  integrity sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==
+
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
+fastify-error@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/fastify-error/-/fastify-error-0.3.1.tgz#8eb993e15e3cf57f0357fc452af9290f1c1278d2"
+  integrity sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==
+
+fastify-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-3.0.0.tgz#cf1b8c8098e3b5a7c8c30e6aeb06903370c054ca"
+  integrity sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w==
+
+fastify-warning@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fastify-warning/-/fastify-warning-0.2.0.tgz#e717776026a4493dc9a2befa44db6d17f618008f"
+  integrity sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==
+
+fastify-websocket@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fastify-websocket/-/fastify-websocket-3.2.0.tgz#69421740671cec95f2001a9dccd393c923d482c0"
+  integrity sha512-O1I04Y6aV2rkO+RRMYQzIe2h7omA20p+Nk/HAdJmfHvNErY7OCani06+rDMmQCKYbZT6RWrsy13U+GrJPhSO6Q==
+  dependencies:
+    fastify-plugin "^3.0.0"
+    ws "^7.4.2"
+
+fastify@^3.17.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-3.18.0.tgz#0be07d67c93c0cd98faf6e0d05287802c417ad89"
+  integrity sha512-D4A5ns+j1NW1PUCYZ0KwThcNCB13JVAXol/zdFFr59A4fIstlk0XACu1Yun0Sxe2a86vd2rG2Q3OmsFVqsQ0LQ==
+  dependencies:
+    "@fastify/ajv-compiler" "^1.0.0"
+    abstract-logging "^2.0.0"
+    avvio "^7.1.2"
+    fast-json-stringify "^2.5.2"
+    fastify-error "^0.3.0"
+    fastify-warning "^0.2.0"
+    find-my-way "^4.0.0"
+    flatstr "^1.0.12"
+    light-my-request "^4.2.0"
+    pino "^6.2.1"
+    proxy-addr "^2.0.7"
+    readable-stream "^3.4.0"
+    rfdc "^1.1.4"
+    secure-json-parse "^2.0.0"
+    semver "^7.3.2"
+    tiny-lru "^7.0.0"
+
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
+
+fastq@^1.6.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
+  integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
+  dependencies:
+    reusify "^1.0.4"
 
 figures@^1.0.1:
   version "1.7.0"
@@ -3065,6 +3224,16 @@ find-cache-dir@^3.0.0:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-my-way@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-4.3.0.tgz#34dc0ec434ef94d6fc5c4b733bb91795821b2575"
+  integrity sha512-uVmpziK3XJrP2PhD2CpMcSPnDZ69f5xESh7OuqgtaHVHszDMlwCS59oVczD1BGZTI6pMm/mrUwi0yfVLfbNC6Q==
+  dependencies:
+    fast-decode-uri-component "^1.0.1"
+    fast-deep-equal "^3.1.3"
+    safe-regex2 "^2.0.0"
+    semver-store "^0.3.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3104,10 +3273,20 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
+
 follow-redirects@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
 fs-access@^1.0.1:
   version "1.0.1"
@@ -3277,6 +3456,22 @@ globrex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
+"graasp-types@git+https://github.com/graasp/graasp-types.git#master":
+  version "0.1.0"
+  resolved "git+https://github.com/graasp/graasp-types.git#219a92c857e26f75f57aabb2048d383ea505c73d"
+
+"graasp-websockets@git://github.com/graasp/graasp-websockets.git#master":
+  version "0.1.0"
+  resolved "git://github.com/graasp/graasp-websockets.git#1bea4cc0676f56dfc6c3799a32db4bd3cf85e317"
+  dependencies:
+    ajv-latest "npm:ajv@^8.6.0"
+    dotenv "^9.0.2"
+    fastify "^3.17.0"
+    fastify-plugin "^3.0.0"
+    fastify-websocket "^3.2.0"
+    graasp-types "git+https://github.com/graasp/graasp-types.git#master"
+    ioredis "^4.27.5"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"
@@ -3508,6 +3703,27 @@ interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+ioredis@^4.27.5:
+  version "4.27.6"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.27.6.tgz#a53d427d3fe75fbd10ed7ad150ce00559df8dcf8"
+  integrity sha512-6W3ZHMbpCa8ByMyC1LJGOi7P2WiOKP9B3resoZOVLDhi+6dDBOW+KNsRq3yI36Hmnb2sifCxHX+YSarTeXh48A==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -3763,6 +3979,16 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3832,6 +4058,17 @@ language-tags@^1.0.5:
   integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
   dependencies:
     language-subtag-registry "~0.3.2"
+
+light-my-request@^4.2.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-4.4.1.tgz#bfa2220316eef4f6465bf2f0667780da6b7f6a71"
+  integrity sha512-FDNRF2mYjthIRWE7O8d/X7AzDx4otQHl4/QXbu3Q/FRwBFcgb+ZoDaUd5HwN53uQXLAiw76osN+Va0NEaOW6rQ==
+  dependencies:
+    ajv "^6.12.2"
+    cookie "^0.4.0"
+    fastify-warning "^0.2.0"
+    readable-stream "^3.6.0"
+    set-cookie-parser "^2.4.1"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -3922,6 +4159,16 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -4497,6 +4744,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-map@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-queue@^6.3.0:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
@@ -4665,6 +4917,23 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pino-std-serializers@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
+  integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@^6.2.1:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.11.3.tgz#0c02eec6029d25e6794fdb6bbea367247d74bc29"
+  integrity sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -5098,6 +5367,14 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+proxy-addr@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -5105,6 +5382,11 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
@@ -5117,6 +5399,16 @@ qs@6.10.1:
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
   dependencies:
     side-channel "^1.0.4"
+
+queue-microtask@^1.1.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz#6d6b66b8207aa2b35eef12be1421bb24c428f652"
+  integrity sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -5224,7 +5516,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5276,6 +5568,23 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
 
 "redux@^3.6.0 || ^4.0.0":
   version "4.1.0"
@@ -5362,6 +5671,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -5403,6 +5717,21 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+ret@~0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
+  integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
+
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.1.4, rfdc@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -5549,10 +5878,27 @@ safe-identifier@^0.4.1:
   resolved "https://registry.yarnpkg.com/safe-identifier/-/safe-identifier-0.4.2.tgz#cf6bfca31c2897c588092d1750d30ef501d59fcb"
   integrity sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==
 
+safe-regex2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-2.0.0.tgz#b287524c397c7a2994470367e0185e1916b1f5b9"
+  integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
+  dependencies:
+    ret "~0.2.0"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+secure-json-parse@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
+  integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==
+
+semver-store@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
+  integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
@@ -5564,7 +5910,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.5, semver@^7.1.1, semver@^7.3.4:
+semver@7.3.5, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -5587,6 +5933,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.1:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5651,6 +6002,14 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+sonic-boom@^1.0.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.4.1.tgz#d35d6a74076624f12e6f917ade7b9d75e918f53e"
+  integrity sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    flatstr "^1.0.12"
 
 source-map-resolve@^0.6.0:
   version "0.6.0"
@@ -5740,6 +6099,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
+
 standard-version@9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-9.1.0.tgz#07589469324d967ffe665fa86ef612949a858a80"
@@ -5765,6 +6129,11 @@ string-hash@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
   integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+
+string-similarity@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.2"
@@ -6001,6 +6370,11 @@ tiny-glob@^0.2.6:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
+tiny-lru@^7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
+  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -6159,6 +6533,13 @@ unquote@~1.1.1:
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
 
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -6265,6 +6646,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^7.4.2:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
+  integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
 
 xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,17 @@
   dependencies:
     ajv "^6.12.6"
 
+"@graasp/websockets@git://github.com/graasp/graasp-websockets.git#master":
+  version "0.1.0"
+  resolved "git://github.com/graasp/graasp-websockets.git#7432f6e9eecaa445fd9750c885768d86cf8c8b18"
+  dependencies:
+    ajv-latest "npm:ajv@^8.6.0"
+    dotenv "^9.0.2"
+    fastify "^3.18.1"
+    fastify-plugin "^3.0.0"
+    fastify-websocket "^3.2.0"
+    ioredis "^4.27.6"
+
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
@@ -3456,17 +3467,6 @@ globrex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
-
-"graasp-websockets@git://github.com/graasp/graasp-websockets.git#master":
-  version "0.1.0"
-  resolved "git://github.com/graasp/graasp-websockets.git#7432f6e9eecaa445fd9750c885768d86cf8c8b18"
-  dependencies:
-    ajv-latest "npm:ajv@^8.6.0"
-    dotenv "^9.0.2"
-    fastify "^3.18.1"
-    fastify-plugin "^3.0.0"
-    fastify-websocket "^3.2.0"
-    ioredis "^4.27.6"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,9 +3120,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-json-stringify@^2.5.2:
-  version "2.7.6"
-  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.7.6.tgz#c7c92f613f90427a809fe66b2d181ee23e0f0749"
-  integrity sha512-ezem8qpAgpad6tXeUhK0aSCS8Fi2vjxTorI9i5M+xrq6UUbTl7/bBTxL1SjRI2zy+qpPkdD4+UblUCQdxRpvIg==
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.7.7.tgz#9e1c0f238f566559c3d4b99ae17a8e545381c16e"
+  integrity sha512-2kiwC/hBlK7QiGALsvj0QxtYwaReLOmAwOWJIxt5WHBB9EwXsqbsu8LCel47yh8NV8CEcFmnZYcXh4BionJcwQ==
   dependencies:
     ajv "^6.11.0"
     deepmerge "^4.2.2"
@@ -3162,10 +3162,10 @@ fastify-websocket@^3.2.0:
     fastify-plugin "^3.0.0"
     ws "^7.4.2"
 
-fastify@^3.17.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/fastify/-/fastify-3.18.0.tgz#0be07d67c93c0cd98faf6e0d05287802c417ad89"
-  integrity sha512-D4A5ns+j1NW1PUCYZ0KwThcNCB13JVAXol/zdFFr59A4fIstlk0XACu1Yun0Sxe2a86vd2rG2Q3OmsFVqsQ0LQ==
+fastify@^3.18.1:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-3.18.1.tgz#b91ac3b4e0a84a670a18e4062bed45572a669c50"
+  integrity sha512-OA0imy/bQCMzf7LUCb/1JI3ZSoA0Jo0MLpYULxV7gpppOpJ8NBxDp2PQoQ0FDqJevZPb7tlZf5JacIQft8x9yw==
   dependencies:
     "@fastify/ajv-compiler" "^1.0.0"
     abstract-logging "^2.0.0"
@@ -3457,21 +3457,16 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
-"graasp-types@git+https://github.com/graasp/graasp-types.git#master":
-  version "0.1.0"
-  resolved "git+https://github.com/graasp/graasp-types.git#219a92c857e26f75f57aabb2048d383ea505c73d"
-
 "graasp-websockets@git://github.com/graasp/graasp-websockets.git#master":
   version "0.1.0"
-  resolved "git://github.com/graasp/graasp-websockets.git#1bea4cc0676f56dfc6c3799a32db4bd3cf85e317"
+  resolved "git://github.com/graasp/graasp-websockets.git#7432f6e9eecaa445fd9750c885768d86cf8c8b18"
   dependencies:
     ajv-latest "npm:ajv@^8.6.0"
     dotenv "^9.0.2"
-    fastify "^3.17.0"
+    fastify "^3.18.1"
     fastify-plugin "^3.0.0"
     fastify-websocket "^3.2.0"
-    graasp-types "git+https://github.com/graasp/graasp-types.git#master"
-    ioredis "^4.27.5"
+    ioredis "^4.27.6"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"
@@ -3704,7 +3699,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-ioredis@^4.27.5:
+ioredis@^4.27.6:
   version "4.27.6"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.27.6.tgz#a53d427d3fe75fbd10ed7ad150ce00559df8dcf8"
   integrity sha512-6W3ZHMbpCa8ByMyC1LJGOi7P2WiOKP9B3resoZOVLDhi+6dDBOW+KNsRq3yI36Hmnb2sifCxHX+YSarTeXh48A==
@@ -6648,9 +6643,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^7.4.2:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
-  integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.1.tgz#44fc000d87edb1d9c53e51fbc69a0ac1f6871d66"
+  integrity sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
PR to track progress on #9 

- [x] Implement WS client for Graasp WS protocol as a singleton
- [x] Write effect hooks that use above client and mutate query client
- [x] Only send subscriptions if not already subscribed
- [ ] Hearbeat mechanism to detect lost WS connection -> cannot be implemented with raw ping from WS protocol: there's no API to access such messages from client side. Maybe create own ping?

Possibility to setup Jest with more unit test, however would need to mock window WebSocket object (not available in NodeJS).

Related:
- #9 
- https://github.com/graasp/graasp-compose/pull/118
- https://github.com/graasp/graasp/pull/39