### PR TITLE
#20 Cache expiration time

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,6 @@
 // React Query Configs
-export const STALE_TIME_MILLISECONDS = 1000 * 60 * 60;
-export const CACHE_TIME_MILLISECONDS = 1000 * 60 * 60;
+
+// time during which cache entry is never refetched
+export const STALE_TIME_MILLISECONDS = 0; // default is 0 to always refetch, can increase to trade load against consistency
+// time during which cache entry is still served while refetches are pending
+export const CACHE_TIME_MILLISECONDS = 1000 * 60 * 5; // default is 5 min

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -18,6 +18,8 @@ type QueryClientConfig = {
   WS_HOST?: string;
   enableWebsocket?: boolean;
   notifier?: Notifier;
+  staleTime?: number;
+  cacheTime?: number;
 };
 
 // Query client retry function decides when and how many times a request should be retried
@@ -58,9 +60,9 @@ export default (config: Partial<QueryClientConfig>) => {
     enableWebsocket: config?.enableWebsocket ?? false,
     notifier: config?.notifier,
     // time until data in cache considered stale if cache not invalidated
-    staleTime: STALE_TIME_MILLISECONDS,
+    staleTime: config?.staleTime ?? STALE_TIME_MILLISECONDS,
     // time before cache labeled as inactive to be garbage collected
-    cacheTime: CACHE_TIME_MILLISECONDS,
+    cacheTime: config?.cacheTime ?? CACHE_TIME_MILLISECONDS,
     retry,
   };
 


### PR DESCRIPTION
This PR:

- sets the recommended default values for `staleTime` and `cacheTime`
- allows consumer clients to override these values at initialization of the exported `queryClient` factory through `QueryClientConfig`
- See #20 for more details