### PR TITLE
Fixes empty favorites crash for new users

### DIFF
--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -111,9 +111,11 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       useQuery({
         queryKey: buildItemsKey(ids),
         queryFn: () =>
-          ids.length == 1
-            ? Api.getItem(ids[0], queryConfig).then((data) => List([data]))
-            : Api.getItems(ids, queryConfig).then((data) => List(data)),
+          ids
+            ? ids.length == 1
+              ? Api.getItem(ids[0], queryConfig).then((data) => List([data]))
+              : Api.getItems(ids, queryConfig).then((data) => List(data))
+            : undefined,
         onSuccess: async (items: List<Item>) => {
           // save items in their own key
           items?.forEach(async (item) => {
@@ -121,7 +123,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
             queryClient.setQueryData(buildItemKey(id), Map(item));
           });
         },
-        enabled: Boolean(ids.length) && ids.every((id) => Boolean(id)),
+        enabled: ids && Boolean(ids.length) && ids.every((id) => Boolean(id)),
         ...defaultOptions,
       }),
 

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -46,8 +46,10 @@ export const getDirectParentId = (path: string) => {
 };
 
 export const hashItemsIds = (ids: UUID[]) =>
-  crypto
-    .createHash('sha1')
-    .update(ids.sort().join(''))
-    .digest('hex')
-    .toString();
+  ids
+    ? crypto
+        .createHash('sha1')
+        .update(ids.sort().join(''))
+        .digest('hex')
+        .toString()
+    : undefined;


### PR DESCRIPTION
Fixes #143 in graasp-compose:
- https://github.com/graasp/graasp-compose/issues/143

Root cause of the crash was improper handling of undefined values for favorite ids. When a new user is created, the favorites extra is not defined. Thus multiple call sites did not have default safe values for undefined.

After merging this PR, the query-client version of graasp-compose MUST be updated