### PR TITLE
refactor: integrate ws hooks into api hooks

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,4 +3,7 @@ module.exports = {
     ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-typescript',
   ],
+  plugins: [
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+  ],
 };

--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -1,25 +1,39 @@
 import { Map } from 'immutable';
-import { useQuery } from 'react-query';
+import { QueryClient, useQuery } from 'react-query';
 import * as Api from '../api';
 import { buildItemChatKey } from '../config/keys';
 import { QueryClientConfig, UUID } from '../types';
+import { configureWsChatHooks } from '../ws';
+import { WebsocketClient } from '../ws/ws-client';
 
-export default (queryConfig: QueryClientConfig) => {
-  const { retry, cacheTime, staleTime } = queryConfig;
+export default (
+  queryClient: QueryClient,
+  queryConfig: QueryClientConfig,
+  websocketClient?: WebsocketClient,
+) => {
+  const { retry, cacheTime, staleTime, enableWebsocket } = queryConfig;
   const defaultOptions = {
     retry,
     cacheTime,
     staleTime,
   };
 
+  const wsHooks =
+    enableWebsocket && websocketClient
+      ? configureWsChatHooks(queryClient, websocketClient)
+      : undefined;
+
   return {
-    useItemChat: (itemId: UUID) =>
-      useQuery({
+    useItemChat: (itemId: UUID, getUpdates: boolean = enableWebsocket) => {
+      wsHooks?.useItemChatUpdates(getUpdates ? itemId : null);
+
+      return useQuery({
         queryKey: buildItemChatKey(itemId),
         queryFn: () =>
           Api.getItemChat(itemId, queryConfig).then((data) => Map(data)),
         ...defaultOptions,
         enabled: Boolean(itemId),
-      }),
+      });
+    },
   };
 };

--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -24,7 +24,9 @@ export default (
       : undefined;
 
   return {
-    useItemChat: (itemId: UUID, getUpdates: boolean = enableWebsocket) => {
+    useItemChat: (itemId: UUID, options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       wsHooks?.useItemChatUpdates(getUpdates ? itemId : null);
 
       return useQuery({

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,15 +1,29 @@
 import { QueryClient } from 'react-query';
-import configureItemHooks from './item';
-import configureMemberHooks from './member';
-import configureItemTagHooks from './itemTag';
-import configureItemFlagHooks from './itemFlag';
-import configureChatHooks from './chat';
 import { QueryClientConfig } from '../types';
+import { WebsocketClient } from '../ws/ws-client';
+import configureChatHooks from './chat';
+import configureItemHooks from './item';
+import configureItemFlagHooks from './itemFlag';
+import configureItemTagHooks from './itemTag';
+import configureMemberHooks from './member';
 
-export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => ({
-  ...configureItemHooks(queryClient, queryConfig),
-  ...configureMemberHooks(queryConfig),
-  ...configureItemTagHooks(queryConfig),
-  ...configureItemFlagHooks(queryConfig),
-  ...configureChatHooks(queryConfig),
-});
+export default (
+  queryClient: QueryClient,
+  queryConfig: QueryClientConfig,
+  websocketClient?: WebsocketClient,
+) => {
+  const memberHooks = configureMemberHooks(queryConfig);
+
+  return {
+    ...configureChatHooks(queryClient, queryConfig, websocketClient),
+    ...configureItemHooks(
+      queryClient,
+      queryConfig,
+      memberHooks.useCurrentMember,
+      websocketClient,
+    ),
+    ...configureItemTagHooks(queryConfig),
+    ...configureItemFlagHooks(queryConfig),
+    ...memberHooks,
+  };
+};

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -40,7 +40,9 @@ export default (
       : undefined;
 
   return {
-    useOwnItems: (getUpdates: boolean = enableWebsocket) => {
+    useOwnItems: (options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       const { data: currentMember } = useCurrentMember();
       itemWsHooks?.useOwnItemsUpdates(
         getUpdates ? currentMember?.get('id') : null,
@@ -63,12 +65,12 @@ export default (
 
     useChildren: (
       id: UUID | undefined,
-      options: { enabled?: boolean; ordered?: boolean } = {
-        enabled: true,
-        ordered: true,
-      },
-      getUpdates: boolean = enableWebsocket,
+      options?: { enabled?: boolean; ordered?: boolean; getUpdates?: boolean },
     ) => {
+      const enabled = options?.enabled ?? true;
+      const ordered = options?.ordered ?? true;
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       itemWsHooks?.useChildrenUpdates(getUpdates ? id : null);
 
       return useQuery({
@@ -77,11 +79,9 @@ export default (
           if (!id) {
             throw new UndefinedArgument();
           }
-          return Api.getChildren(
-            id,
-            options?.ordered,
-            queryConfig,
-          ).then((data) => List(data));
+          return Api.getChildren(id, ordered, queryConfig).then((data) =>
+            List(data),
+          );
         },
         onSuccess: async (items: List<Item>) => {
           if (items?.size) {
@@ -93,7 +93,7 @@ export default (
           }
         },
         ...defaultOptions,
-        enabled: Boolean(id) && options?.enabled,
+        enabled: Boolean(id) && enabled,
       });
     },
 
@@ -123,7 +123,9 @@ export default (
         enabled: enabled && Boolean(id),
       }),
 
-    useSharedItems: (getUpdates: boolean = enableWebsocket) => {
+    useSharedItems: (options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       const { data: currentMember } = useCurrentMember();
       itemWsHooks?.useSharedItemsUpdates(
         getUpdates ? currentMember?.get('id') : null,
@@ -144,7 +146,9 @@ export default (
       });
     },
 
-    useItem: (id?: UUID, getUpdates: boolean = enableWebsocket) => {
+    useItem: (id?: UUID, options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       itemWsHooks?.useItemUpdates(getUpdates ? id : null);
 
       return useQuery({
@@ -161,7 +165,9 @@ export default (
     },
 
     // todo: add optimisation to avoid fetching items already in cache
-    useItems: (ids: UUID[], getUpdates: boolean = enableWebsocket) => {
+    useItems: (ids: UUID[], options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       ids.map((id) => itemWsHooks?.useItemUpdates(getUpdates ? id : null));
 
       return useQuery({
@@ -184,7 +190,9 @@ export default (
       });
     },
 
-    useItemMemberships: (id?: UUID, getUpdates: boolean = enableWebsocket) => {
+    useItemMemberships: (id?: UUID, options?: { getUpdates?: boolean }) => {
+      const getUpdates = options?.getUpdates ?? enableWebsocket;
+
       membershipWsHooks?.useItemMembershipsUpdates(getUpdates ? id : null);
 
       return useQuery({

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -8,7 +8,7 @@ import {
 import configureHooks from './hooks';
 import configureMutations from './mutations';
 import type { QueryClientConfig } from './types';
-import configureWebSockets from './ws';
+import { configureWebsocketClient } from './ws';
 
 export type Notifier = (e: any) => any;
 
@@ -71,19 +71,16 @@ export default (config: Partial<QueryClientConfig>) => {
   configureMutations(queryClient, queryConfig);
 
   // set up hooks given config
-  const hooks = configureHooks(queryClient, queryConfig);
-
-  // set up websocket client and hooks given config
-  const ws = queryConfig.enableWebsocket
-    ? { ws: configureWebSockets(queryClient, queryConfig) }
-    : {};
+  const websocketClient = queryConfig.enableWebsocket
+    ? configureWebsocketClient(queryConfig)
+    : undefined;
+  const hooks = configureHooks(queryClient, queryConfig, websocketClient);
 
   // returns the queryClient and relative instances
   return {
     queryClient,
     QueryClientProvider,
     hooks,
-    ...ws,
     useMutation,
     ReactQueryDevtools,
   };

--- a/src/ws/hooks/chat.ts
+++ b/src/ws/hooks/chat.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
 import { buildItemChatKey } from '../../config/keys';
 import { Chat, ChatMessage, UUID } from '../../types';
-import { Channel, GraaspWebsocketClient } from '../ws-client';
+import { Channel, WebsocketClient } from '../ws-client';
 
 // todo: use graasp-types?
 interface ChatEvent {
@@ -12,15 +12,15 @@ interface ChatEvent {
   message: ChatMessage;
 }
 
-export default (
-  websocketClient: GraaspWebsocketClient,
+export const configureWsChatHooks = (
   queryClient: QueryClient,
+  websocketClient: WebsocketClient,
 ) => ({
   /**
    * React hook to subscribe to the updates of the given chat ID
    * @param chatId The ID of the chat of which to observe updates
    */
-  useItemChatUpdates: (chatId: UUID) => {
+  useItemChatUpdates: (chatId: UUID | null) => {
     useEffect(() => {
       if (!chatId) {
         return;

--- a/src/ws/hooks/index.ts
+++ b/src/ws/hooks/index.ts
@@ -1,16 +1,3 @@
-import { QueryClient } from 'react-query';
-import { GraaspWebsocketClient } from '../ws-client';
-import configureChatHooks from './chat';
-import configureItemHooks from './item';
-import configureMembershipHooks from './membership';
-
-export default (
-  websocketClient: GraaspWebsocketClient,
-  queryClient: QueryClient,
-) => {
-  return {
-    ...configureItemHooks(websocketClient, queryClient),
-    ...configureMembershipHooks(websocketClient, queryClient),
-    ...configureChatHooks(websocketClient, queryClient),
-  };
-};
+export { configureWsChatHooks } from './chat';
+export { configureWsItemHooks } from './item';
+export { configureWsMembershipHooks } from './membership';

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -13,7 +13,7 @@ import {
   SHARED_ITEMS_KEY,
 } from '../../config/keys';
 import { Item, UUID } from '../../types';
-import { Channel, GraaspWebsocketClient } from '../ws-client';
+import { Channel, WebsocketClient } from '../ws-client';
 
 // TODO: use graasp-types?
 interface ItemEvent {
@@ -22,15 +22,15 @@ interface ItemEvent {
   item: Item;
 }
 
-export default (
-  websocketClient: GraaspWebsocketClient,
+export const configureWsItemHooks = (
   queryClient: QueryClient,
+  websocketClient: WebsocketClient,
 ) => ({
   /**
    * React hook to subscribe to the updates of the given item ID
    * @param itemId The ID of the item of which to observe updates
    */
-  useItemUpdates: (itemId: UUID) => {
+  useItemUpdates: (itemId?: UUID | null) => {
     useEffect(() => {
       if (!itemId) {
         return;
@@ -73,7 +73,7 @@ export default (
    * React hook to subscribe to the children updates of the given parent item ID
    * @param parentId The ID of the parent on which to observe children updates
    */
-  useChildrenUpdates: (parentId: UUID) => {
+  useChildrenUpdates: (parentId?: UUID | null) => {
     useEffect(() => {
       if (!parentId) {
         return;
@@ -131,7 +131,7 @@ export default (
    * React hook to subscribe to the owned items updates of the given user ID
    * @param userId The ID of the user on which to observe owned items updates
    */
-  useOwnItemsUpdates: (userId: UUID) => {
+  useOwnItemsUpdates: (userId?: UUID | null) => {
     useEffect(() => {
       if (!userId) {
         return;
@@ -189,7 +189,7 @@ export default (
    * React hook to subscribe to the shared items updates of the given user ID
    * @param parentId The ID of the user on which to observe shared items updates
    */
-  useSharedItemsUpdates: (userId: UUID) => {
+  useSharedItemsUpdates: (userId?: UUID | null) => {
     useEffect(() => {
       if (!userId) {
         return;

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -3,7 +3,7 @@
  * React effect hooks to subscribe to real-time updates and mutate query client
  */
 
-import { List, Record } from 'immutable';
+import { List, Map, Record } from 'immutable';
 import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
 import {
@@ -49,7 +49,7 @@ export const configureWsItemHooks = (
           if (current?.get('id') === item.id) {
             switch (event.op) {
               case 'update': {
-                queryClient.setQueryData(itemKey, item);
+                queryClient.setQueryData(itemKey, Map(item));
                 break;
               }
               case 'delete': {
@@ -97,7 +97,7 @@ export const configureWsItemHooks = (
                 if (!current.find((i) => i.id === item.id)) {
                   mutation = current.push(item);
                   queryClient.setQueryData(parentChildrenKey, mutation);
-                  queryClient.setQueryData(buildItemKey(item.id), item);
+                  queryClient.setQueryData(buildItemKey(item.id), Map(item));
                 }
                 break;
               }
@@ -105,7 +105,7 @@ export const configureWsItemHooks = (
                 // replace value if it exists
                 mutation = current.map((i) => (i.id === item.id ? item : i));
                 queryClient.setQueryData(parentChildrenKey, mutation);
-                queryClient.setQueryData(buildItemKey(item.id), item);
+                queryClient.setQueryData(buildItemKey(item.id), Map(item));
 
                 break;
               }
@@ -154,7 +154,7 @@ export const configureWsItemHooks = (
                 if (!current.find((i) => i.id === item.id)) {
                   mutation = current.push(item);
                   queryClient.setQueryData(OWN_ITEMS_KEY, mutation);
-                  queryClient.setQueryData(buildItemKey(item.id), item);
+                  queryClient.setQueryData(buildItemKey(item.id), Map(item));
                 }
                 break;
               }
@@ -162,7 +162,7 @@ export const configureWsItemHooks = (
                 // replace value if it exists
                 mutation = current.map((i) => (i.id === item.id ? item : i));
                 queryClient.setQueryData(OWN_ITEMS_KEY, mutation);
-                queryClient.setQueryData(buildItemKey(item.id), item);
+                queryClient.setQueryData(buildItemKey(item.id), Map(item));
 
                 break;
               }
@@ -212,7 +212,7 @@ export const configureWsItemHooks = (
                 if (!current.find((i) => i.id === item.id)) {
                   mutation = current.push(item);
                   queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
-                  queryClient.setQueryData(buildItemKey(item.id), item);
+                  queryClient.setQueryData(buildItemKey(item.id), Map(item));
                 }
                 break;
               }
@@ -220,7 +220,7 @@ export const configureWsItemHooks = (
                 // replace value if it exists
                 mutation = current.map((i) => (i.id === item.id ? item : i));
                 queryClient.setQueryData(SHARED_ITEMS_KEY, mutation);
-                queryClient.setQueryData(buildItemKey(item.id), item);
+                queryClient.setQueryData(buildItemKey(item.id), Map(item));
 
                 break;
               }

--- a/src/ws/hooks/membership.ts
+++ b/src/ws/hooks/membership.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
 import { buildItemMembershipsKey } from '../../config/keys';
 import { Membership, UUID } from '../../types';
-import { Channel, GraaspWebsocketClient } from '../ws-client';
+import { Channel, WebsocketClient } from '../ws-client';
 
 // todo: use graasp-types?
 interface MembershipEvent {
@@ -12,15 +12,15 @@ interface MembershipEvent {
   membership: Membership;
 }
 
-export default (
-  websocketClient: GraaspWebsocketClient,
+export const configureWsMembershipHooks = (
   queryClient: QueryClient,
+  websocketClient: WebsocketClient,
 ) => ({
   /**
    * React hooks to subscribe to membership updates for a given item ID
    * @param itemId The ID of the item of which to observe memberships updates
    */
-  useItemMembershipsUpdates: (itemId: UUID) => {
+  useItemMembershipsUpdates: (itemId?: UUID | null) => {
     useEffect(() => {
       if (!itemId) {
         return;

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -2,17 +2,5 @@
  * Graasp websocket client top-level file
  * Entry point to use the Graasp WebSocket client in front-end applications
  */
-
-import { QueryClient } from 'react-query';
-import { QueryClientConfig } from '../types';
-import configureWebsocketHooks from './hooks';
-import { configureWebsocketClient } from './ws-client';
-
-// to be called by the main query client configurator
-export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
-  const websocketClient = configureWebsocketClient(queryConfig);
-
-  return {
-    hooks: configureWebsocketHooks(websocketClient, queryClient),
-  };
-};
+export * from './hooks';
+export { configureWebsocketClient } from './ws-client';

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -72,7 +72,7 @@ function keyToChannel(key: string): Channel {
 /**
  * Websocket client for the graasp-websockets protocol
  */
-export interface GraaspWebsocketClient {
+export interface WebsocketClient {
   /**
    * Subscribe a handler to a given channel
    * @param channel Channel to which to subscribe to
@@ -90,7 +90,7 @@ export interface GraaspWebsocketClient {
 
 export const configureWebsocketClient = (
   config: QueryClientConfig,
-): GraaspWebsocketClient => {
+): WebsocketClient => {
   // native client WebSocket instance
   const ws = new WebSocket(config.WS_HOST);
 


### PR DESCRIPTION
This PR improves on #48 by integrating the websocket hooks into the API hooks directly, each with a boolean allowing consumer to enable websocket updates

Front-end applications that still use the previously `ws` exported member should update (Compose, Perform, ...).
Example:

```ts
// before
const item = useItem(itemId)
ws.hooks.useItemUpdates()
```

```ts
// should now be
const item = useItem(itemId)

// specific components can also optionally opt-out from receiving websocket updates:
const item = useItem(itemId, {getUpdates: false})
```