### PR TITLE
fix: trim items names on add and edit

### DIFF
--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes';
 import {
   buildCopyItemRoute,
   buildDeleteItemRoute,
@@ -26,7 +27,6 @@ import {
 } from './utils';
 import { getParentsIdsFromPath } from '../utils/item';
 import { ExtendedItem, Item, QueryClientConfig, UUID } from '../types';
-import { StatusCodes } from 'http-status-codes';
 
 export const getItem = async (id: UUID, { API_HOST }: QueryClientConfig) => {
   let res = await fetch(`${API_HOST}/${buildGetItemRoute(id)}`, DEFAULT_GET);
@@ -74,7 +74,7 @@ export const postItem = async (
 ) => {
   const res = await fetch(`${API_HOST}/${buildPostItemRoute(parentId)}`, {
     ...DEFAULT_POST,
-    body: JSON.stringify({ name, type, description, extra }),
+    body: JSON.stringify({ name: name.trim(), type, description, extra }),
   }).then(failOnError);
 
   const newItem = await res.json();
@@ -112,7 +112,10 @@ export const editItem = async (
 ) => {
   const req = await fetch(`${API_HOST}/${buildEditItemRoute(id)}`, {
     ...DEFAULT_PATCH,
-    body: JSON.stringify(item),
+    body: JSON.stringify({
+      ...item,
+      name: item.name?.trim()
+    }),
   }).then(failOnError);
 
   const newItem = await req.json();

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -115,21 +115,19 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: (item) => Api.editItem(item.id, item, queryConfig),
     // newItem contains only changed values
     onMutate: async (newItem: Partial<Item>) => {
-      newItem = {
+      const trimmed = {
         ...newItem,
         name: newItem.name?.trim()
       };
 
-      console.log(newItem);
-
-      const itemKey = buildItemKey(newItem.id);
+      const itemKey = buildItemKey(trimmed.id);
 
       // invalidate key
       await queryClient.cancelQueries(itemKey);
 
       // build full item with new values
       const prevItem = queryClient.getQueryData(itemKey) as Record<Item>;
-      const newFullItem = prevItem.merge(newItem);
+      const newFullItem = prevItem.merge(trimmed);
 
       const previousItems = {
         parent: await mutateParentChildren({
@@ -138,7 +136,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
             if (!old || old.isEmpty()) {
               return old;
             }
-            const idx = old.findIndex(({ id }) => id === newItem.id);
+            const idx = old.findIndex(({ id }) => id === trimmed.id);
             // todo: remove toJS when moving to List<Map<Item>>
             return old.set(idx, newFullItem.toJS());
           },

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -115,6 +115,13 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: (item) => Api.editItem(item.id, item, queryConfig),
     // newItem contains only changed values
     onMutate: async (newItem: Partial<Item>) => {
+      newItem = {
+        ...newItem,
+        name: newItem.name?.trim()
+      };
+
+      console.log(newItem);
+
       const itemKey = buildItemKey(newItem.id);
 
       // invalidate key


### PR DESCRIPTION
This trim the item's name when created or edited.

closes #52 , grasp-compose#153