### PR TITLE
fix: remove cookie when logout is confirmed, prevents logout loop

### DIFF
--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -12,16 +12,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
   queryClient.setMutationDefaults(MUTATION_KEYS.SIGN_OUT, {
     mutationFn: () => Api.signOut(queryConfig),
-    onMutate: async () => {
-      // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-      await queryClient.cancelQueries(CURRENT_MEMBER_KEY);
-
-      // Snapshot the previous value
-      const previousMember = queryClient.getQueryData(CURRENT_MEMBER_KEY);
-
-      // Return a context object with the snapshotted value
-      return { previousMember };
-    },
     onSuccess: () => {
       notifier?.({ type: signOutRoutine.SUCCESS });
       queryClient.resetQueries();

--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -24,9 +24,8 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       queryClient.setQueryData(CURRENT_MEMBER_KEY, undefined);
     },
     // If the mutation fails, use the context returned from onMutate to roll back
-    onError: (error, _args, context) => {
+    onError: (error, _args, _context) => {
       notifier?.({ type: signOutRoutine.FAILURE, payload: { error } });
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, context.previousMember);
     },
   });
 

--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -19,9 +19,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       // Snapshot the previous value
       const previousMember = queryClient.getQueryData(CURRENT_MEMBER_KEY);
 
-      // Optimistically update to the new value
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, null);
-
       // Return a context object with the snapshotted value
       return { previousMember };
     },
@@ -29,8 +26,12 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       notifier?.({ type: signOutRoutine.SUCCESS });
       queryClient.resetQueries();
 
-      // remove cookies from browser
+      // remove cookies from browser when the logout is confirmed
       Cookies.remove(COOKIE_SESSION_NAME);
+
+      // Update when the server confirmed the logout, instead optimistically updating the member 
+      // This prevents logout loop (redirect to logout -> still cookie -> logs back in)
+      queryClient.setQueryData(CURRENT_MEMBER_KEY, undefined);
     },
     // If the mutation fails, use the context returned from onMutate to roll back
     onError: (error, _args, context) => {


### PR DESCRIPTION
This only update the user state when the backend confirms the logout

close #40 