### PR TITLE
fix: export routes

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -253,6 +253,7 @@ export const API_ROUTES = {
   buildGetCategoriesRoute,
   buildGetCategoryRoute,
   buildGetItemCategoriesRoute,
+  buildGetItemsInCategoryRoute,
   buildPostItemCategoryRoute,
   buildDeleteItemCategoryRoute,
   buildUploadItemThumbnailRoute,


### PR DESCRIPTION
close #108 

A simple bug fix to export the route `getItemsInCategories`