### PR TITLE
fix: change route url to public

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -211,7 +211,7 @@ export const buildGetPublicApiAccessTokenRoute = (id: UUID) =>
   `${PUBLIC_PREFIX}/${buildGetApiAccessTokenRoute(id)}`;
 
 export const buildGetItemsByKeywordRoute = (range: string, keywords: string) =>
-  `${ITEMS_ROUTE}/search/${range}/${keywords}`;
+  `${PUBLIC_PREFIX}/${ITEMS_ROUTE}/search/${range}/${keywords}`;
 
 export const API_ROUTES = {
   APPS_ROUTE,


### PR DESCRIPTION
Since now the search-plugin is registered as public, update corresponding route in hook