### PR TITLE
fix: fallback and merge private and public reponse for arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "husky install",
     "predeploy": "cd example && yarn install && yarn run build",
-    "test:watch": "jest src/hooks/item.test.ts --watchAll",
+    "test:watch": "jest --watchAll",
     "test": "jest src --silent",
     "test:ci": "yarn && cd example && yarn && cd .. && yarn test",
     "deploy": "gh-pages -d example/build",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "husky install",
     "predeploy": "cd example && yarn install && yarn run build",
-    "test:watch": "jest src --watchAll",
+    "test:watch": "jest src/hooks/item.test.ts --watchAll",
     "test": "jest src --silent",
     "test:ci": "yarn && cd example && yarn && cd .. && yarn test",
     "deploy": "gh-pages -d example/build",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -28,20 +28,28 @@ const returnFallbackDataOrThrow = (error: Error, fallbackData: unknown) => {
   throw error;
 };
 
-const fallbackForArray = async (data: unknown, publicRequest: () => Promise<AxiosResponse>,) => {
+const fallbackForArray = async (
+  data: unknown,
+  publicRequest: () => Promise<AxiosResponse>,
+) => {
   // the array contains an error
-  if (Array.isArray(data) && data.some(d => FALLBACK_TO_PUBLIC_FOR_STATUS_CODES.includes(d?.statusCode))) {
-    const publicCall = await publicRequest()
-    const { data: publicData } = publicCall
+  if (
+    Array.isArray(data) &&
+    data.some((d) =>
+      FALLBACK_TO_PUBLIC_FOR_STATUS_CODES.includes(d?.statusCode),
+    )
+  ) {
+    const publicCall = await publicRequest();
+    const { data: publicData } = publicCall;
 
     // merge private and public valid data
     const finalData = data.map((d, idx) =>
-      d?.statusCode ? publicData[idx] : d
-    )
+      d?.statusCode ? publicData[idx] : d,
+    );
     return finalData;
   }
-  return data
-}
+  return data;
+};
 
 /**
  * Automatically send request depending on whether member is authenticated

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -28,6 +28,21 @@ const returnFallbackDataOrThrow = (error: Error, fallbackData: unknown) => {
   throw error;
 };
 
+const fallbackForArray = async (data: unknown, publicRequest: () => Promise<AxiosResponse>,) => {
+  // the array contains an error
+  if (Array.isArray(data) && data.some(d => FALLBACK_TO_PUBLIC_FOR_STATUS_CODES.includes(d?.statusCode))) {
+    const publicCall = await publicRequest()
+    const { data: publicData } = publicCall
+
+    // merge private and public valid data
+    const finalData = data.map((d, idx) =>
+      d?.statusCode ? publicData[idx] : d
+    )
+    return finalData;
+  }
+  return data
+}
+
 /**
  * Automatically send request depending on whether member is authenticated
  * The function fallback to public depending on status code or authentication
@@ -49,7 +64,7 @@ export const fallbackToPublic = (
   }
 
   return request()
-    .then(({ data }) => data)
+    .then(({ data }) => fallbackForArray(data, publicRequest))
     .catch((error) => {
       if (FALLBACK_TO_PUBLIC_FOR_STATUS_CODES.includes(error.response.status)) {
         return publicRequest()

--- a/src/api/itemTag.ts
+++ b/src/api/itemTag.ts
@@ -21,7 +21,10 @@ export const getItemTags = async (id: UUID, { API_HOST }: QueryClientConfig) =>
       .get(`${API_HOST}/${buildGetItemTagsRoute(id)}`)
       .then(({ data }) => data),
   );
-export const getItemsTags = async (ids: UUID[], { API_HOST }: QueryClientConfig) =>
+export const getItemsTags = async (
+  ids: UUID[],
+  { API_HOST }: QueryClientConfig,
+) =>
   verifyAuthentication(() =>
     axios
       .get(`${API_HOST}/${buildGetItemsTagsRoute(ids)}`)

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -138,10 +138,10 @@ export const buildSignInPath = (to: string) => {
 export const SIGN_OUT_ROUTE = 'logout';
 export const buildGetItemTagsRoute = (id: UUID) => `${ITEMS_ROUTE}/${id}/tags`;
 export const buildGetItemsTagsRoute = (ids: UUID[]) =>
-`${ITEMS_ROUTE}/tags?${qs.stringify(
-  { id: ids },
-  { arrayFormat: 'repeat' },
-)}`;
+  `${ITEMS_ROUTE}/tags?${qs.stringify(
+    { id: ids },
+    { arrayFormat: 'repeat' },
+  )}`;
 export const buildPostItemTagRoute = (id: UUID) => `${ITEMS_ROUTE}/${id}/tags`;
 export const buildPutItemLoginSchema = (id: UUID) =>
   `${ITEMS_ROUTE}/${id}/login-schema`;
@@ -285,5 +285,6 @@ export const API_ROUTES = {
   buildImportZipRoute,
   buildGetApiAccessTokenRoute,
   buildGetPublicApiAccessTokenRoute,
-  buildPublicDownloadFilesRoute
+  buildPublicDownloadFilesRoute,
+  buildGetPublicItemMembershipsForItemsRoute
 };

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -23,9 +23,9 @@ export const buildPostItemRoute = (parentId?: UUID) => {
 };
 export const buildDeleteItemRoute = (id: UUID) => `${ITEMS_ROUTE}/${id}/delete`;
 export const buildDeleteItemsRoute = (ids: UUID[]) =>
-  `${ITEMS_ROUTE}/delete?${qs.stringify(
+  `${ITEMS_ROUTE}/delete${qs.stringify(
     { id: ids },
-    { arrayFormat: 'repeat' },
+    { arrayFormat: 'repeat', addQueryPrefix: true },
   )}`;
 export const buildGetChildrenRoute = (id: UUID, ordered: boolean) =>
   `${ITEMS_ROUTE}/${id}/children${qs.stringify(
@@ -138,10 +138,7 @@ export const buildSignInPath = (to: string) => {
 export const SIGN_OUT_ROUTE = 'logout';
 export const buildGetItemTagsRoute = (id: UUID) => `${ITEMS_ROUTE}/${id}/tags`;
 export const buildGetItemsTagsRoute = (ids: UUID[]) =>
-  `${ITEMS_ROUTE}/tags?${qs.stringify(
-    { id: ids },
-    { arrayFormat: 'repeat' },
-  )}`;
+  `${ITEMS_ROUTE}/tags?${qs.stringify({ id: ids }, { arrayFormat: 'repeat' })}`;
 export const buildPostItemTagRoute = (id: UUID) => `${ITEMS_ROUTE}/${id}/tags`;
 export const buildPutItemLoginSchema = (id: UUID) =>
   `${ITEMS_ROUTE}/${id}/login-schema`;
@@ -168,9 +165,9 @@ export const buildPostItemFlagRoute = (id: UUID) =>
 export const buildRecycleItemRoute = (id: UUID) =>
   `${ITEMS_ROUTE}/${id}/recycle`;
 export const buildRecycleItemsRoute = (ids: UUID[]) =>
-  `${ITEMS_ROUTE}/recycle?${qs.stringify(
+  `${ITEMS_ROUTE}/recycle${qs.stringify(
     { id: ids },
-    { arrayFormat: 'repeat' },
+    { arrayFormat: 'repeat', addQueryPrefix: true },
   )}`;
 export const buildGetPublicItemsWithTag = (options: { tagId: UUID }) =>
   `${PUBLIC_PREFIX}/${ITEMS_ROUTE}?${qs.stringify(options)}`;
@@ -182,9 +179,9 @@ export const buildGetPublicMembersRoute = (ids: UUID[]) =>
 
 export const buildGetPublicMember = (id: UUID) => `p/${MEMBERS_ROUTE}/${id}`;
 export const buildRestoreItemsRoute = (ids: UUID[]) =>
-  `${ITEMS_ROUTE}/restore?${qs.stringify(
+  `${ITEMS_ROUTE}/restore${qs.stringify(
     { id: ids },
-    { arrayFormat: 'repeat' },
+    { arrayFormat: 'repeat', addQueryPrefix: true },
   )}`;
 
 export const GET_CATEGORY_TYPES_ROUTE = `${PUBLIC_PREFIX}/${ITEMS_ROUTE}/category-types`;

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -126,4 +126,5 @@ export const MUTATION_KEYS = {
   DELETE_ITEM_CATEGORY: 'deleteItemCategory',
   UPLOAD_ITEM_THUMBNAIL: 'uploadItemThumbnail',
   UPLOAD_AVATAR: 'uploadAvatar',
+  IMPORT_ZIP: 'importZip',
 };

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -11,6 +11,7 @@ import {
   buildGetItemMembershipsForItemsRoute,
   buildGetItemRoute,
   buildGetItemsRoute,
+  buildGetPublicItemMembershipsForItemsRoute,
   buildGetPublicItemRoute,
   buildGetPublicItemsWithTag,
   buildPublicDownloadFilesRoute,
@@ -589,6 +590,24 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       // verify cache keys
       expect(queryClient.getQueryData(key)).toBeFalsy();
+    });
+
+    // this tests fallbackForArray
+    it(`Merge private and public data if result with correct data and errors`, async () => {
+      const hook = () => hooks.useItemMemberships(ids);
+      const publicRoute = `/${buildGetPublicItemMembershipsForItemsRoute(ids)}`;
+      const publicResponse = [{ statusCode: StatusCodes.FORBIDDEN }, ITEM_MEMBERSHIPS_RESPONSE];
+      const privateResponse = [ITEM_MEMBERSHIPS_RESPONSE, { statusCode: StatusCodes.FORBIDDEN }];
+      const endpoints = [{ route, response: privateResponse }, { route: publicRoute, response: publicResponse }];
+      const { data } = await mockHook({
+        endpoints,
+        hook,
+        wrapper,
+      });
+
+      expect((data as List<Membership[]>).toJS()).toEqual(response);
+      // verify cache keys
+      expect(queryClient.getQueryData(key)).toEqual(List(response));
     });
 
     it(`Unauthorized`, async () => {

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -596,9 +596,18 @@ describe('Items Hooks', () => {
     it(`Merge private and public data if result with correct data and errors`, async () => {
       const hook = () => hooks.useItemMemberships(ids);
       const publicRoute = `/${buildGetPublicItemMembershipsForItemsRoute(ids)}`;
-      const publicResponse = [{ statusCode: StatusCodes.FORBIDDEN }, ITEM_MEMBERSHIPS_RESPONSE];
-      const privateResponse = [ITEM_MEMBERSHIPS_RESPONSE, { statusCode: StatusCodes.FORBIDDEN }];
-      const endpoints = [{ route, response: privateResponse }, { route: publicRoute, response: publicResponse }];
+      const publicResponse = [
+        { statusCode: StatusCodes.FORBIDDEN },
+        ITEM_MEMBERSHIPS_RESPONSE,
+      ];
+      const privateResponse = [
+        ITEM_MEMBERSHIPS_RESPONSE,
+        { statusCode: StatusCodes.FORBIDDEN },
+      ];
+      const endpoints = [
+        { route, response: privateResponse },
+        { route: publicRoute, response: publicResponse },
+      ];
       const { data } = await mockHook({
         endpoints,
         hook,

--- a/src/hooks/itemTag.test.ts
+++ b/src/hooks/itemTag.test.ts
@@ -4,7 +4,11 @@ import { v4 } from 'uuid'
 import { StatusCodes } from 'http-status-codes';
 import Cookies from 'js-cookie';
 import { List } from 'immutable';
-import { buildGetItemsTagsRoute, buildGetItemTagsRoute, GET_TAGS_ROUTE } from '../api/routes';
+import {
+  buildGetItemsTagsRoute,
+  buildGetItemTagsRoute,
+  GET_TAGS_ROUTE,
+} from '../api/routes';
 import { mockHook, setUpTest } from '../../test/utils';
 import { ITEMS, TAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { buildItemTagsKey, TAGS_KEY } from '../config/keys';
@@ -102,7 +106,7 @@ describe('Item Tags Hooks', () => {
   describe('useItemsTags', () => {
     const itemsIds = ITEMS.map(({ id }) => id);
     const route = `/${buildGetItemsTagsRoute(itemsIds)}`;
-    const keys = itemsIds.map(itemId => buildItemTagsKey(itemId));
+    const keys = itemsIds.map((itemId) => buildItemTagsKey(itemId));
 
     const hook = () => hooks.useItemsTags(itemsIds);
 
@@ -115,7 +119,9 @@ describe('Item Tags Hooks', () => {
       expect((data as List<List<typeof TAGS[0]>>).toJS()).toEqual(response);
 
       // verify cache keys
-      keys.forEach(key => expect(queryClient.getQueryData(key)).toEqual(List(TAGS)));
+      keys.forEach((key) =>
+        expect(queryClient.getQueryData(key)).toEqual(List(TAGS)),
+      );
 
       expect(isSuccess).toBeTruthy();
     });

--- a/src/hooks/itemTag.ts
+++ b/src/hooks/itemTag.ts
@@ -5,7 +5,6 @@ import * as Api from '../api';
 import { buildItemTagsKey, buildManyItemTagsKey, TAGS_KEY } from '../config/keys';
 import { isError } from '../utils/item'
 
-
 export default (queryConfig: QueryClientConfig, queryClient: QueryClient) => {
   const { retry, cacheTime, staleTime } = queryConfig;
   const defaultOptions = {

--- a/src/hooks/search.test.ts
+++ b/src/hooks/search.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import Cookies from 'js-cookie';
 import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -631,7 +631,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       notifier?.({ type: uploadFileRoutine.FAILURE, payload: { error } });
     },
     onSettled: (_data, _error, { id }) => {
-      const parentKey = buildItemChildrenKey(id);
+      const parentKey = getKeyForParentId(id);
       queryClient.invalidateQueries(parentKey);
     },
   });

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -15,6 +15,7 @@ import {
   recycleItemsRoutine,
   restoreItemsRoutine,
   uploadItemThumbnailRoutine,
+  importZipRoutine,
 } from '../routines';
 import {
   buildItemChildrenKey,
@@ -28,7 +29,7 @@ import {
   buildItemThumbnailKey,
 } from '../config/keys';
 import { buildPath, getDirectParentId } from '../utils/item';
-import type { Item, QueryClientConfig, UUID } from '../types';
+import type { GraaspError, Item, QueryClientConfig, UUID } from '../types';
 import { THUMBNAIL_SIZES } from '../config/constants';
 
 const {
@@ -47,6 +48,7 @@ const {
   RESTORE_ITEMS,
   UPLOAD_ITEM_THUMBNAIL,
   COPY_PUBLIC_ITEM,
+  IMPORT_ZIP,
 } = MUTATION_KEYS;
 
 interface Value {
@@ -329,7 +331,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
   queryClient.setMutationDefaults(DELETE_ITEMS, {
     mutationFn: (itemIds) =>
-      Api.deleteItems(itemIds, queryConfig).then(() => itemIds),
+      Api.deleteItems(itemIds, queryConfig).then((data) => List(data)),
 
     onMutate: async (itemIds: UUID[]) => {
       // get path from first item
@@ -349,8 +351,18 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
       return previousItems;
     },
-    onSuccess: () => {
-      notifier?.({ type: deleteItemRoutine.SUCCESS });
+    onSuccess: (result) => {
+      const errors = result.filter(
+        (r: Item | GraaspError) => (r as GraaspError).statusCode,
+      );
+      if (!errors.isEmpty()) {
+        // todo: revert deleted items
+        return notifier?.({
+          type: deleteItemsRoutine.FAILURE,
+          payload: { error: errors.first() },
+        });
+      }
+      return notifier?.({ type: deleteItemsRoutine.SUCCESS });
     },
     onError: (error, itemIds: UUID[], context) => {
       const itemPath = context[itemIds[0]]?.get('path');
@@ -660,6 +672,24 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
         queryClient.invalidateQueries(key);
       });
       queryClient.invalidateQueries(buildItemKey(id));
+    },
+  });
+
+  queryClient.setMutationDefaults(IMPORT_ZIP, {
+    mutationFn: async ({ error }) => {
+      if (error) {
+        throw new Error(JSON.stringify(error));
+      }
+    },
+    onSuccess: () => {
+      notifier?.({ type: importZipRoutine.SUCCESS });
+    },
+    onError: (_error, { error }) => {
+      notifier?.({ type: importZipRoutine.FAILURE, payload: { error } });
+    },
+    onSettled: (_data, _error, { id }) => {
+      const parentKey = getKeyForParentId(id);
+      queryClient.invalidateQueries(parentKey);
     },
   });
 


### PR DESCRIPTION
This PR allows to use both private and public data for array response. This is needed because array response are always valid, even though the content is an error. This prevents to fallback on the public endpoint.

close #124 