### PR TITLE
131/error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "dist/index.modern.js",
   "source": "src/index.ts",
   "dependencies": {
+    "@graasp/translations": "github:graasp/graasp-translations.git#1/init",
     "axios": "0.24.0",
     "http-status-codes": "2.2.0",
     "immutable": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.modern.js",
   "source": "src/index.ts",
   "dependencies": {
-    "@graasp/translations": "github:graasp/graasp-translations.git#1/init",
+    "@graasp/translations": "github:graasp/graasp-translations.git",
     "axios": "0.24.0",
     "http-status-codes": "2.2.0",
     "immutable": "4.0.0",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,20 +6,6 @@ import { isObject } from '../utils/util';
 
 const configureAxios = () => {
   axios.defaults.withCredentials = true;
-  // // eslint-disable-next-line arrow-body-style
-  // axios.interceptors.response.use((response) => {
-  //   // Any status code that lie within the range of 2xx cause this function to trigger
-  //   // Do something with response data
-  //   return response
-  //   // eslint-disable-next-line arrow-body-style
-  // }, (error) => {
-  //   // Any status codes that falls outside the range of 2xx cause this function to trigger
-  //   // Do something with response error
-
-  //   // return graasp error
-  //   console.log(error, error?.response)
-  //   return error?.response?.data
-  // })
   return axios;
 };
 
@@ -104,7 +90,7 @@ export const fallbackToPublic = (
 export const throwIfArrayContainsErrorOrReturn = (array: any[]) => {
   const errors = array?.filter((value) => isObject(value) && value.statusCode);
   if (errors.length) {
-    // suppose all errors are the same
+    // assume all errors are the same
     // build axios error from error data received
     const error = {
       response: { data: errors[0] },

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,10 +1,25 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 import { isUserAuthenticated } from './utils';
 import { FALLBACK_TO_PUBLIC_FOR_STATUS_CODES } from '../config/constants';
 import { UserIsSignedOut } from '../config/errors';
+import { isObject } from '../utils/util';
 
 const configureAxios = () => {
   axios.defaults.withCredentials = true;
+  // // eslint-disable-next-line arrow-body-style
+  // axios.interceptors.response.use((response) => {
+  //   // Any status code that lie within the range of 2xx cause this function to trigger
+  //   // Do something with response data
+  //   return response
+  //   // eslint-disable-next-line arrow-body-style
+  // }, (error) => {
+  //   // Any status codes that falls outside the range of 2xx cause this function to trigger
+  //   // Do something with response error
+
+  //   // return graasp error
+  //   console.log(error, error?.response)
+  //   return error?.response?.data
+  // })
   return axios;
 };
 
@@ -82,6 +97,21 @@ export const fallbackToPublic = (
 
       return returnFallbackDataOrThrow(error, fallbackData);
     });
+};
+
+// this function is used to purposely trigger an error for react-query
+// especially when the request returns positively with an array of errors (ie: copy many items)
+export const throwIfArrayContainsErrorOrReturn = (array: any[]) => {
+  const errors = array?.filter((value) => isObject(value) && value.statusCode);
+  if (errors.length) {
+    // suppose all errors are the same
+    // build axios error from error data received
+    const error = {
+      response: { data: errors[0] },
+    } as AxiosError;
+    throw error;
+  }
+  return array;
 };
 
 export default configureAxios;

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -107,7 +107,7 @@ export const MUTATION_KEYS = {
   MOVE_ITEM: 'moveItem',
   MOVE_ITEMS: 'moveItems',
   SHARE_ITEM: 'shareItem',
-  FILE_UPLOAD: 'fileUpload',
+  UPLOAD_FILES: 'uploadFiles',
   SIGN_OUT: 'signOut',
   POST_ITEM_LOGIN: 'postItemLoginSignIn',
   buildItemMembershipsKey: (id: UUID) => [ITEMS_KEY, id, 'memberships'],

--- a/src/config/messages.ts
+++ b/src/config/messages.ts
@@ -1,6 +1,6 @@
 export const ERROR_MESSAGE_HEADER = 'Error';
 export const SUCCESS_MESSAGE_HEADER = 'Success';
-export const FILE_UPLOAD_INFO_MESSAGE_HEADER = 'File Upload';
+export const UPLOAD_FILE_INFO_MESSAGE_HEADER = 'File Upload';
 export const GET_SHARED_ITEMS_ERROR_MESSAGE =
   'There was an error fetching items.';
 export const GET_ITEM_ERROR_MESSAGE = 'There was an error fetching the item.';

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import Cookies from 'js-cookie';
 import { List, Map, Record } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
@@ -1756,8 +1757,8 @@ describe('Items Mutations', () => {
     });
   });
 
-  describe(MUTATION_KEYS.FILE_UPLOAD, () => {
-    const mutation = () => useMutation(MUTATION_KEYS.FILE_UPLOAD);
+  describe(MUTATION_KEYS.UPLOAD_FILES, () => {
+    const mutation = () => useMutation(MUTATION_KEYS.UPLOAD_FILES);
     const { id } = ITEMS[0];
 
     it('Upload one item', async () => {
@@ -1776,7 +1777,7 @@ describe('Items Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate({ id });
+        await mockedMutation.mutate({ data: [id], id });
         await waitForMutation();
       });
 
@@ -1787,6 +1788,7 @@ describe('Items Mutations', () => {
       // check notification trigger
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: uploadFileRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_FILES },
       });
     });
 
@@ -2030,7 +2032,7 @@ describe('Items Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate({ id });
+        await mockedMutation.mutate({ id, data: [id] });
         await waitForMutation();
       });
 
@@ -2043,6 +2045,7 @@ describe('Items Mutations', () => {
       }
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: uploadItemThumbnailRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_ITEM_THUMBNAIL },
       });
     });
 

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -38,7 +38,7 @@ const {
   POST_ITEM,
   DELETE_ITEM,
   EDIT_ITEM,
-  FILE_UPLOAD,
+  UPLOAD_FILES,
   SHARE_ITEM,
   MOVE_ITEM,
   MOVE_ITEMS,
@@ -271,7 +271,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: () => {
-      notifier?.({ type: recycleItemsRoutine.SUCCESS });
+      notifier?.({
+        type: recycleItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.RECYCLE_ITEMS },
+      });
     },
     onError: (error, itemIds: UUID[], context) => {
       const itemKey = buildItemKey(itemIds[0]);
@@ -318,7 +321,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: () => {
-      notifier?.({ type: deleteItemRoutine.SUCCESS });
+      notifier?.({
+        type: deleteItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM },
+      });
     },
     onError: (error, [itemId], context) => {
       const itemData = context.item;
@@ -377,7 +383,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
           payload: { error: errors.first() },
         });
       }
-      return notifier?.({ type: deleteItemsRoutine.SUCCESS });
+      return notifier?.({
+        type: deleteItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEMS },
+      });
     },
     onError: (error, itemIds: UUID[], context) => {
       const itemPath = context[itemIds[0]]?.get('path');
@@ -414,8 +423,11 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
         ...newItem,
       })),
     // cannot mutate because it needs the id
-    onSuccess: (data) => {
-      notifier?.({ type: copyItemRoutine.SUCCESS, payload: data });
+    onSuccess: () => {
+      notifier?.({
+        type: copyItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.COPY_ITEM },
+      });
     },
     onError: (error) => {
       notifier?.({ type: copyItemRoutine.FAILURE, payload: { error } });
@@ -432,8 +444,11 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
         to: payload.to,
         ...newItem,
       })),
-    onSuccess: (data) => {
-      notifier?.({ type: copyItemRoutine.SUCCESS, payload: data });
+    onSuccess: () => {
+      notifier?.({
+        type: copyItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.COPY_ITEM },
+      });
     },
     onError: (error) => {
       notifier?.({ type: copyItemRoutine.FAILURE, payload: { error } });
@@ -455,7 +470,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       }),
     // cannot mutate because it needs the id
     onSuccess: () => {
-      notifier?.({ type: copyItemsRoutine.SUCCESS });
+      notifier?.({
+        type: copyItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.COPY_ITEMS },
+      });
     },
     onError: (error) => {
       notifier?.({ type: copyItemsRoutine.FAILURE, payload: { error } });
@@ -507,7 +525,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return context;
     },
     onSuccess: () => {
-      notifier?.({ type: moveItemRoutine.SUCCESS });
+      notifier?.({
+        type: moveItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.MOVE_ITEM },
+      });
     },
     // If the mutation fails, use the context returned from onMutate to roll back
     onError: (error, { id, to }, context) => {
@@ -592,7 +613,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return context;
     },
     onSuccess: () => {
-      notifier?.({ type: moveItemsRoutine.SUCCESS });
+      notifier?.({
+        type: moveItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.MOVE_ITEMS },
+      });
     },
     // If the mutation fails, use the context returned from onMutate to roll back
     onError: (error, { id: itemIds, to }, context) => {
@@ -633,7 +657,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   queryClient.setMutationDefaults(SHARE_ITEM, {
     mutationFn: (payload) => Api.shareItemWith(payload, queryConfig),
     onSuccess: () => {
-      notifier?.({ type: shareItemRoutine.SUCCESS });
+      notifier?.({
+        type: shareItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.SHARE_ITEM },
+      });
     },
     onError: (error) => {
       notifier?.({ type: shareItemRoutine.FAILURE, payload: { error } });
@@ -652,15 +679,22 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
    * @param {UUID} id parent item id wher the file is uploaded in
    * @param {error} [error] error occured during the file uploading
    */
-  queryClient.setMutationDefaults(FILE_UPLOAD, {
-    mutationFn: async ({ error }) => {
+  queryClient.setMutationDefaults(UPLOAD_FILES, {
+    mutationFn: async ({ error, data }) => {
+      throwIfArrayContainsErrorOrReturn(data);
       if (error) throw new Error(JSON.stringify(error));
     },
     onSuccess: () => {
-      notifier?.({ type: uploadFileRoutine.SUCCESS });
+      notifier?.({
+        type: uploadFileRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_FILES },
+      });
     },
-    onError: (_error, { error }) => {
-      notifier?.({ type: uploadFileRoutine.FAILURE, payload: { error } });
+    onError: (axiosError, { error }) => {
+      notifier?.({
+        type: uploadFileRoutine.FAILURE,
+        payload: { error: error ?? axiosError },
+      });
     },
     onSettled: (_data, _error, { id }) => {
       const parentKey = getKeyForParentId(id);
@@ -678,7 +712,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       if (error) throw new Error(JSON.stringify(error));
     },
     onSuccess: () => {
-      notifier?.({ type: uploadItemThumbnailRoutine.SUCCESS });
+      notifier?.({
+        type: uploadItemThumbnailRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_ITEM_THUMBNAIL },
+      });
     },
     onError: (_error, { error }) => {
       notifier?.({
@@ -742,7 +779,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
           queryClient.invalidateQueries(key);
         }
       }
-      notifier?.({ type: restoreItemsRoutine.SUCCESS });
+      notifier?.({
+        type: restoreItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.RESTORE_ITEMS },
+      });
     },
     onError: (error, _itemId, context) => {
       queryClient.setQueryData(RECYCLED_ITEMS_KEY, context);

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -1,5 +1,6 @@
 import { List, Record, Map } from 'immutable';
 import { QueryClient } from 'react-query';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import * as Api from '../api';
 import {
   copyItemRoutine,
@@ -111,7 +112,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: async (item) => Api.postItem(item, queryConfig),
     // we cannot optimistically add an item because we need its id
     onSuccess: () => {
-      notifier?.({ type: createItemRoutine.SUCCESS });
+      notifier?.({
+        type: createItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.CREATE_ITEM },
+      });
     },
     onError: (error) => {
       notifier?.({ type: createItemRoutine.FAILURE, payload: { error } });
@@ -161,7 +165,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: () => {
-      notifier?.({ type: editItemRoutine.SUCCESS });
+      notifier?.({
+        type: editItemRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.EDIT_ITEM },
+      });
     },
     onError: (error, newItem, context) => {
       const { item: prevItem } = context;
@@ -208,7 +215,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: () => {
-      notifier?.({ type: recycleItemsRoutine.SUCCESS });
+      notifier?.({
+        type: recycleItemsRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.RECYCLE_ITEM },
+      });
     },
     onError: (error, _itemId, context) => {
       const itemData = context.item;
@@ -692,7 +702,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       }
     },
     onSuccess: () => {
-      notifier?.({ type: importZipRoutine.SUCCESS });
+      notifier?.({
+        type: importZipRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.IMPORT_ZIP },
+      });
     },
     onError: (_error, { error }) => {
       notifier?.({ type: importZipRoutine.FAILURE, payload: { error } });

--- a/src/mutations/itemCategory.test.ts
+++ b/src/mutations/itemCategory.test.ts
@@ -4,6 +4,7 @@ import Cookies from 'js-cookie';
 import { act } from 'react-test-renderer';
 import { List } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { REQUEST_METHODS } from '../api/utils';
 import { buildItemCategoriesKey, MUTATION_KEYS } from '../config/keys';
@@ -65,6 +66,7 @@ describe('Item Category Mutations', () => {
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: postItemCategoryRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_CATEGORY },
       });
     });
     it('Unauthorized to post item category', async () => {

--- a/src/mutations/itemCategory.ts
+++ b/src/mutations/itemCategory.ts
@@ -1,3 +1,4 @@
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { QueryClient } from 'react-query';
 import * as Api from '../api';
 import { buildItemCategoriesKey, MUTATION_KEYS } from '../config/keys';
@@ -14,7 +15,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: (payload) =>
       Api.postItemCategory(payload, queryConfig).then(() => payload),
     onSuccess: () => {
-      notifier?.({ type: postItemCategoryRoutine.SUCCESS });
+      notifier?.({
+        type: postItemCategoryRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_CATEGORY },
+      });
     },
     onError: (error) => {
       notifier?.({ type: postItemCategoryRoutine.FAILURE, payload: { error } });
@@ -27,7 +31,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   queryClient.setMutationDefaults(MUTATION_KEYS.DELETE_ITEM_CATEGORY, {
     mutationFn: (payload) => Api.deleteItemCategory(payload, queryConfig),
     onSuccess: () => {
-      notifier?.({ type: deleteItemCategoryRoutine.SUCCESS });
+      notifier?.({
+        type: deleteItemCategoryRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM_CATEGORY },
+      });
     },
     onError: (error) => {
       notifier?.({

--- a/src/mutations/itemFlag.test.ts
+++ b/src/mutations/itemFlag.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
 import Cookies from 'js-cookie';
@@ -57,6 +58,7 @@ describe('Item Flag Mutations', () => {
       expect(queryClient.getQueryState(flagKey)?.isInvalidated).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: postItemFlagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_FLAG },
       });
     });
 

--- a/src/mutations/itemFlag.ts
+++ b/src/mutations/itemFlag.ts
@@ -1,3 +1,4 @@
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { QueryClient } from 'react-query';
 import { buildItemFlagsKey, MUTATION_KEYS } from '../config/keys';
 import { postItemFlagRoutine } from '../routines';
@@ -10,7 +11,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   queryClient.setMutationDefaults(MUTATION_KEYS.POST_ITEM_FLAG, {
     mutationFn: (payload) => Api.postItemFlag(payload, queryConfig),
     onSuccess: () => {
-      notifier?.({ type: postItemFlagRoutine.SUCCESS });
+      notifier?.({
+        type: postItemFlagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_FLAG },
+      });
     },
     onError: (error) => {
       notifier?.({ type: postItemFlagRoutine.FAILURE, payload: { error } });

--- a/src/mutations/itemLogin.test.ts
+++ b/src/mutations/itemLogin.test.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import Cookies from 'js-cookie';
 import { Map } from 'immutable';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { act } from 'react-test-renderer';
 import {
   ITEMS,
@@ -151,6 +152,7 @@ describe('Item Login Mutations', () => {
       ).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: putItemLoginRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.PUT_ITEM_LOGIN },
       });
     });
 

--- a/src/mutations/itemLogin.ts
+++ b/src/mutations/itemLogin.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from 'react-query';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import * as Api from '../api';
 import { putItemLoginRoutine, postItemLoginRoutine } from '../routines';
 import { MUTATION_KEYS, buildItemLoginKey } from '../config/keys';
@@ -23,7 +24,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   queryClient.setMutationDefaults(PUT_ITEM_LOGIN, {
     mutationFn: (payload) => Api.putItemLoginSchema(payload, queryConfig),
     onSuccess: () => {
-      notifier?.({ type: putItemLoginRoutine.SUCCESS });
+      notifier?.({
+        type: putItemLoginRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.PUT_ITEM_LOGIN },
+      });
     },
     onError: (error) => {
       notifier?.({ type: putItemLoginRoutine.FAILURE, payload: { error } });

--- a/src/mutations/itemTag.test.ts
+++ b/src/mutations/itemTag.test.ts
@@ -2,6 +2,7 @@
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { List } from 'immutable';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { act } from 'react-test-renderer';
 import Cookies from 'js-cookie';
 import {
@@ -69,6 +70,7 @@ describe('Item Tag Mutations', () => {
       expect(queryClient.getQueryState(itemTagKey)?.isInvalidated).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: postItemTagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_TAG },
       });
     });
 
@@ -146,6 +148,7 @@ describe('Item Tag Mutations', () => {
       );
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: deleteItemTagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM_TAG },
       });
     });
 

--- a/src/mutations/itemTag.ts
+++ b/src/mutations/itemTag.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from 'react-query';
 import { List } from 'immutable';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { buildItemTagsKey, MUTATION_KEYS } from '../config/keys';
 import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
 import * as Api from '../api';
@@ -12,7 +13,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: (payload) =>
       Api.postItemTag(payload, queryConfig).then(() => payload),
     onSuccess: () => {
-      notifier?.({ type: postItemTagRoutine.SUCCESS });
+      notifier?.({
+        type: postItemTagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.POST_ITEM_TAG },
+      });
     },
     onError: (error) => {
       notifier?.({ type: postItemTagRoutine.FAILURE, payload: { error } });
@@ -42,7 +46,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return { itemTags: prevValue };
     },
     onSuccess: () => {
-      notifier?.({ type: deleteItemTagRoutine.SUCCESS });
+      notifier?.({
+        type: deleteItemTagRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM_TAG },
+      });
     },
     onError: (error, { id }, context) => {
       const itemKey = buildItemTagsKey(id);

--- a/src/mutations/member.test.ts
+++ b/src/mutations/member.test.ts
@@ -4,6 +4,7 @@ import { act } from '@testing-library/react-hooks';
 import { Map, Record } from 'immutable';
 import nock from 'nock';
 import Cookies from 'js-cookie';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import {
   buildPatchMember,
   buildUploadAvatarRoute,
@@ -187,7 +188,7 @@ describe('Member Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate({ id });
+        await mockedMutation.mutate({ id, data: [id] });
         await waitForMutation();
       });
 
@@ -200,6 +201,7 @@ describe('Member Mutations', () => {
       }
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: uploadAvatarRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_AVATAR },
       });
     });
 

--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from 'react-query';
 import { Map, Record } from 'immutable';
 import Cookies from 'js-cookie';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import * as Api from '../api';
 import {
   editMemberRoutine,
@@ -14,6 +15,7 @@ import {
 } from '../config/keys';
 import { Member, QueryClientConfig } from '../types';
 import { COOKIE_SESSION_NAME, THUMBNAIL_SIZES } from '../config/constants';
+import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const { notifier } = queryConfig;
@@ -21,7 +23,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   queryClient.setMutationDefaults(MUTATION_KEYS.SIGN_OUT, {
     mutationFn: () => Api.signOut(queryConfig),
     onSuccess: () => {
-      notifier?.({ type: signOutRoutine.SUCCESS });
+      notifier?.({
+        type: signOutRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.SIGN_OUT },
+      });
       queryClient.resetQueries();
 
       // remove cookies from browser when the logout is confirmed
@@ -60,7 +65,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return { previousMember };
     },
     onSuccess: () => {
-      notifier?.({ type: editMemberRoutine.SUCCESS });
+      notifier?.({
+        type: editMemberRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.EDIT_MEMBER },
+      });
     },
     // If the mutation fails, use the context returned from onMutate to roll back
     onError: (error, _, context) => {
@@ -80,11 +88,15 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
    * @param {error} [error] error occured during the file uploading
    */
   queryClient.setMutationDefaults(MUTATION_KEYS.UPLOAD_AVATAR, {
-    mutationFn: async ({ error } = {}) => {
+    mutationFn: async ({ error, data } = {}) => {
+      throwIfArrayContainsErrorOrReturn(data);
       if (error) throw new Error(JSON.stringify(error));
     },
     onSuccess: () => {
-      notifier?.({ type: uploadAvatarRoutine.SUCCESS });
+      notifier?.({
+        type: uploadAvatarRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.UPLOAD_AVATAR },
+      });
     },
     onError: (_error, { error }) => {
       notifier?.({ type: uploadAvatarRoutine.FAILURE, payload: { error } });

--- a/src/mutations/membership.test.ts
+++ b/src/mutations/membership.test.ts
@@ -4,6 +4,7 @@ import { List } from 'immutable';
 import { act } from 'react-test-renderer';
 import { StatusCodes } from 'http-status-codes';
 import Cookies from 'js-cookie';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import {
   ITEMS,
   ITEM_MEMBERSHIPS_RESPONSE,
@@ -77,6 +78,7 @@ describe('Membership Mutations', () => {
       ).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: editItemMembershipRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.EDIT_ITEM_MEMBERSHIP },
       });
     });
 
@@ -148,6 +150,7 @@ describe('Membership Mutations', () => {
       ).toEqual(memberships.filter(({ id }) => id !== membershipId));
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: deleteItemMembershipRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM_MEMBERSHIP },
       });
     });
 

--- a/src/mutations/membership.ts
+++ b/src/mutations/membership.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from 'react-query';
 import { List } from 'immutable';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 import * as Api from '../api';
 import {
   deleteItemMembershipRoutine,
@@ -20,7 +21,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     mutationFn: ({ id, permission }: { id: UUID; permission: string }) =>
       Api.editItemMembership({ id, permission }, queryConfig),
     onSuccess: () => {
-      notifier?.({ type: editItemMembershipRoutine.SUCCESS });
+      notifier?.({
+        type: editItemMembershipRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.EDIT_ITEM_MEMBERSHIP },
+      });
     },
     onError: (error) => {
       notifier?.({
@@ -49,7 +53,10 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return { memberships };
     },
     onSuccess: () => {
-      notifier?.({ type: deleteItemMembershipRoutine.SUCCESS });
+      notifier?.({
+        type: deleteItemMembershipRoutine.SUCCESS,
+        payload: { message: SUCCESS_MESSAGES.DELETE_ITEM_MEMBERSHIP },
+      });
     },
     onError: (error, { itemId }, context) => {
       const membershipsKey = buildItemMembershipsKey(itemId);

--- a/src/routines/thumbnails.ts
+++ b/src/routines/thumbnails.ts
@@ -1,0 +1,7 @@
+import { MUTATION_KEYS } from '..';
+import createRoutine from './utils';
+
+// eslint-disable-next-line import/prefer-default-export
+export const uploadItemThumbnailRoutine = createRoutine(
+  MUTATION_KEYS.UPLOAD_ITEM_THUMBNAIL,
+);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,0 +1,3 @@
+// eslint-disable-next-line import/prefer-default-export
+export const isObject = (value: unknown) =>
+  typeof value === 'object' && !Array.isArray(value) && value !== null;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes';
 import {
   Item,
   ItemLogin,
@@ -11,7 +12,12 @@ import {
 
 export const WS_HOST = 'ws://localhost:3000';
 export const API_HOST = 'http://localhost:3000';
-export const UNAUTHORIZED_RESPONSE = { some: 'error' };
+export const UNAUTHORIZED_RESPONSE = {
+  name: 'unauthorized',
+  code: 'ERRCODE',
+  message: 'unauthorized error message',
+  statusCode: StatusCodes.UNAUTHORIZED,
+};
 export const ITEMS: Item[] = [
   {
     id: '42',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,7 +1944,7 @@ __metadata:
     "@babel/preset-typescript": 7.16.7
     "@commitlint/cli": 16.0.1
     "@commitlint/config-conventional": 16.0.0
-    "@graasp/translations": "github:graasp/graasp-translations.git#1/init"
+    "@graasp/translations": "github:graasp/graasp-translations.git"
     "@testing-library/jest-dom": 5.16.1
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
@@ -1992,12 +1992,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graasp/translations@github:graasp/graasp-translations.git#1/init":
+"@graasp/translations@github:graasp/graasp-translations.git":
   version: 0.1.0
-  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=47feb6b18e9cf305cc75e073167d716d9c14abee"
+  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=452c17c0b4b5a5e216b8d647a9f821071b179213"
   dependencies:
     i18next: 21.6.11
-  checksum: 91f7c6bf3a857c3868b7931fe46510c194519bc1a8432dc4ff05d3fa9dc14db51ded64b7b893553109fa0993b678bd5e3ce469d668ff371af75650ffb32c2841
+  checksum: b375f4ea5982845d74e354003017a872dc21c012da42c58f05d3ef4e086335788e9335a0c59c4954a6f489e0f89d97b17e10916e653eb6edf6f78f18fa89e878
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,6 +1597,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.0":
+  version: 7.17.2
+  resolution: "@babel/runtime@npm:7.17.2"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: a48702d271ecc59c09c397856407afa29ff980ab537b3da58eeee1aeaa0f545402d340a1680c9af58aec94dfdcbccfb6abb211991b74686a86d03d3f6956cacd
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.10.4, @babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
@@ -1935,6 +1944,7 @@ __metadata:
     "@babel/preset-typescript": 7.16.7
     "@commitlint/cli": 16.0.1
     "@commitlint/config-conventional": 16.0.0
+    "@graasp/translations": "github:graasp/graasp-translations.git#1/init"
     "@testing-library/jest-dom": 5.16.1
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
@@ -1981,6 +1991,15 @@ __metadata:
     react: ^17.0.0
   languageName: unknown
   linkType: soft
+
+"@graasp/translations@github:graasp/graasp-translations.git#1/init":
+  version: 0.1.0
+  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=47feb6b18e9cf305cc75e073167d716d9c14abee"
+  dependencies:
+    i18next: 21.6.11
+  checksum: 91f7c6bf3a857c3868b7931fe46510c194519bc1a8432dc4ff05d3fa9dc14db51ded64b7b893553109fa0993b678bd5e3ce469d668ff371af75650ffb32c2841
+  languageName: node
+  linkType: hard
 
 "@hapi/address@npm:2.x.x":
   version: 2.1.4
@@ -9786,6 +9805,15 @@ __metadata:
   version: 1.0.4
   resolution: "hyphenate-style-name@npm:1.0.4"
   checksum: 4f5bf4b055089754924babebaa23c17845937bcca6aee95d5d015f8fa1e6814279002bd6a9e541e3fac2cd02519fc76305396727066c57c8e21a7e73e7a12137
+  languageName: node
+  linkType: hard
+
+"i18next@npm:21.6.11":
+  version: 21.6.11
+  resolution: "i18next@npm:21.6.11"
+  dependencies:
+    "@babel/runtime": ^7.12.0
+  checksum: 42716a7519d6066a8c9400639ab80fba0b568ae02205b1155ec9c4e627704bb2181dd182ff5eb0c91f6c67c8038ddd0754214e1932de5699d488c21ffd617c5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR controls better multi items endpoints, as it might result in a failed request even though the request's code is valid. The request will contain the error data.

I've also added some success messages for better error handling, on review I will apply it on all mutations. 

close #131 