### PR TITLE
refactor: use graasp sdk, update types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,8 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "importOrder": ["^@?graasp", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "source": "src/index.ts",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@graasp/sdk": "github:graasp/graasp-sdk",
+    "@graasp/sdk": "github:graasp/graasp-sdk#42/limits",
     "@graasp/translations": "github:graasp/graasp-translations.git",
     "@graasp/utils": "github:graasp/graasp-utils.git",
     "axios": "0.27.2",
@@ -34,6 +34,7 @@
     "@testing-library/react": "12.1.4",
     "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "14.1.1",
+    "@trivago/prettier-plugin-sort-imports": "3.2.0",
     "@types/crypto-js": "4.1.1",
     "@types/jest": "28.1.0",
     "@types/js-cookie": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "http-status-codes": "2.2.0",
     "immutable": "4.0.0",
     "jest-immutable-matchers": "3.0.0",
-    "js-cookie": "3.0.1",
     "qs": "6.10.3",
     "react-query": "3.34.19",
     "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "crypto-js": "4.1.1",
     "http-status-codes": "2.2.0",
     "immutable": "4.0.0",
-    "jest-immutable-matchers": "3.0.0",
     "qs": "6.10.3",
     "react-query": "3.34.19",
     "uuid": "8.3.2"
@@ -58,6 +57,7 @@
     "husky": "7.0.4",
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
+    "jest-immutable-matchers": "3.0.0",
     "microbundle-crl": "0.13.11",
     "mock-socket": "9.1.2",
     "nock": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "source": "src/index.ts",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@graasp/sdk": "github:graasp/graasp-sdk#42/limits",
+    "@graasp/sdk": "github:graasp/graasp-sdk",
     "@graasp/translations": "github:graasp/graasp-translations.git",
     "@graasp/utils": "github:graasp/graasp-utils.git",
     "axios": "0.27.2",

--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -1,13 +1,13 @@
-import {
-  buildAppListRoute,
-  buildGetApiAccessTokenRoute,
-  buildGetPublicApiAccessTokenRoute,
-} from './routes';
 import { QueryClientConfig, UUID } from '../types';
 import configureAxios, {
   fallbackToPublic,
   verifyAuthentication,
 } from './axios';
+import {
+  buildAppListRoute,
+  buildGetApiAccessTokenRoute,
+  buildGetPublicApiAccessTokenRoute,
+} from './routes';
 
 const axios = configureAxios();
 

--- a/src/api/authentication.ts
+++ b/src/api/authentication.ts
@@ -1,3 +1,5 @@
+import { HttpMethod } from '@graasp/sdk';
+
 import { QueryClientConfig } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
 import {
@@ -6,7 +8,6 @@ import {
   SIGN_OUT_ROUTE,
   SIGN_UP_ROUTE,
 } from './routes';
-import { REQUEST_METHODS } from './utils';
 
 const axios = configureAxios();
 
@@ -25,7 +26,7 @@ export const signInWithPassword = async (
   { API_HOST }: QueryClientConfig,
 ) =>
   axios({
-    method: REQUEST_METHODS.POST,
+    method: HttpMethod.POST,
     url: `${API_HOST}/${SIGN_IN_WITH_PASSWORD_ROUTE}`,
     data: payload,
     // Resolve only if the status code is less than 500

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { isUserAuthenticated } from './utils';
+
 import { FALLBACK_TO_PUBLIC_FOR_STATUS_CODES } from '../config/constants';
 import { UserIsSignedOut } from '../config/errors';
 import { isObject } from '../utils/util';
+import { isUserAuthenticated } from './utils';
 
 const configureAxios = () => {
   axios.defaults.withCredentials = true;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
+import { isUserAuthenticated } from '@graasp/sdk';
+
 import { FALLBACK_TO_PUBLIC_FOR_STATUS_CODES } from '../config/constants';
 import { UserIsSignedOut } from '../config/errors';
 import { isObject } from '../utils/util';
-import { isUserAuthenticated } from './utils';
 
 const configureAxios = () => {
   axios.defaults.withCredentials = true;

--- a/src/api/category.ts
+++ b/src/api/category.ts
@@ -4,14 +4,14 @@ import configureAxios, {
   verifyAuthentication,
 } from './axios';
 import {
-  buildGetCategoriesRoute,
-  buildGetItemCategoriesRoute,
-  buildPostItemCategoryRoute,
-  buildDeleteItemCategoryRoute,
   GET_CATEGORY_TYPES_ROUTE,
-  buildGetPublicItemCategoriesRoute,
+  buildDeleteItemCategoryRoute,
+  buildGetCategoriesRoute,
   buildGetCategoryRoute,
+  buildGetItemCategoriesRoute,
   buildGetItemsInCategoryRoute,
+  buildGetPublicItemCategoriesRoute,
+  buildPostItemCategoryRoute,
 } from './routes';
 
 const axios = configureAxios();

--- a/src/api/invitation.ts
+++ b/src/api/invitation.ts
@@ -3,8 +3,8 @@ import configureAxios, { verifyAuthentication } from './axios';
 import {
   buildDeleteInvitationRoute,
   buildGetInvitationRoute,
-  buildPatchInvitationRoute,
   buildGetItemInvitationsForItemRoute,
+  buildPatchInvitationRoute,
   buildPostInvitationsRoute,
   buildResendInvitationRoute,
 } from './routes';

--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -1,4 +1,16 @@
+import { Item } from '@graasp/sdk';
+
+import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
+import { QueryClientConfig, UUID } from '../types';
+import { getParentsIdsFromPath } from '../utils/item';
+import configureAxios, {
+  fallbackToPublic,
+  verifyAuthentication,
+} from './axios';
 import {
+  GET_OWN_ITEMS_ROUTE,
+  GET_RECYCLED_ITEMS_ROUTE,
+  SHARED_ITEM_WITH_ROUTE,
   buildCopyItemRoute,
   buildCopyItemsRoute,
   buildCopyPublicItemRoute,
@@ -21,17 +33,7 @@ import {
   buildRecycleItemRoute,
   buildRecycleItemsRoute,
   buildRestoreItemsRoute,
-  GET_OWN_ITEMS_ROUTE,
-  GET_RECYCLED_ITEMS_ROUTE,
-  SHARED_ITEM_WITH_ROUTE,
 } from './routes';
-import { getParentsIdsFromPath } from '../utils/item';
-import { ExtendedItem, Item, QueryClientConfig, UUID } from '../types';
-import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
-import configureAxios, {
-  fallbackToPublic,
-  verifyAuthentication,
-} from './axios';
 
 const axios = configureAxios();
 
@@ -56,7 +58,15 @@ export const getOwnItems = async ({ API_HOST }: QueryClientConfig) =>
 // payload = {name, type, description, extra}
 // querystring = {parentId}
 export const postItem = async (
-  { name, type, description, extra, parentId }: ExtendedItem,
+  {
+    name,
+    type,
+    description,
+    extra,
+    parentId,
+  }: Item & {
+    parentId: UUID;
+  },
   { API_HOST }: QueryClientConfig,
 ) =>
   verifyAuthentication(() =>

--- a/src/api/itemFlag.ts
+++ b/src/api/itemFlag.ts
@@ -1,6 +1,6 @@
 import { QueryClientConfig, UUID } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
-import { buildPostItemFlagRoute, GET_FLAGS_ROUTE } from './routes';
+import { GET_FLAGS_ROUTE, buildPostItemFlagRoute } from './routes';
 
 const axios = configureAxios();
 

--- a/src/api/itemLike.ts
+++ b/src/api/itemLike.ts
@@ -1,11 +1,11 @@
+import { QueryClientConfig, UUID } from '../types';
+import configureAxios, { verifyAuthentication } from './axios';
 import {
   buildDeleteItemLikeRoute,
   buildGetLikeCountRoute,
   buildGetLikedItemsRoute,
   buildPostItemLikeRoute,
 } from './routes';
-import { QueryClientConfig, UUID } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
 
 const axios = configureAxios();
 

--- a/src/api/itemLogin.ts
+++ b/src/api/itemLogin.ts
@@ -1,10 +1,10 @@
+import { QueryClientConfig, UUID } from '../types';
+import configureAxios, { verifyAuthentication } from './axios';
 import {
   buildGetItemLoginRoute,
   buildPostItemLoginSignInRoute,
   buildPutItemLoginSchema,
 } from './routes';
-import { QueryClientConfig, UUID } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
 
 const axios = configureAxios();
 

--- a/src/api/itemTag.ts
+++ b/src/api/itemTag.ts
@@ -1,12 +1,12 @@
-import {
-  buildDeleteItemTagRoute,
-  buildGetItemsTagsRoute,
-  buildGetItemTagsRoute,
-  buildPostItemTagRoute,
-  GET_TAGS_ROUTE,
-} from './routes';
 import { QueryClientConfig, UUID } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
+import {
+  GET_TAGS_ROUTE,
+  buildDeleteItemTagRoute,
+  buildGetItemTagsRoute,
+  buildGetItemsTagsRoute,
+  buildPostItemTagRoute,
+} from './routes';
 
 const axios = configureAxios();
 

--- a/src/api/itemValidation.ts
+++ b/src/api/itemValidation.ts
@@ -1,13 +1,13 @@
 import { QueryClientConfig, UUID } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
 import {
+  GET_ITEM_VALIDATION_REVIEWS_ROUTE,
+  GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE,
+  GET_ITEM_VALIDATION_STATUSES_ROUTE,
   buildGetItemValidationAndReviewRoute,
   buildGetItemValidationGroupsRoute,
   buildPostItemValidationRoute,
   buildUpdateItemValidationReviewRoute,
-  GET_ITEM_VALIDATION_REVIEWS_ROUTE,
-  GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE,
-  GET_ITEM_VALIDATION_STATUSES_ROUTE,
 } from './routes';
 
 const axios = configureAxios();

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,30 +1,27 @@
 import { StatusCodes } from 'http-status-codes';
-import {
-  buildGetMembersBy,
-  buildGetMember,
-  GET_CURRENT_MEMBER_ROUTE,
-  buildPatchMember,
-  buildGetMembersRoute,
-  buildGetPublicMembersRoute,
-  buildGetPublicMember,
-  buildUploadAvatarRoute,
-  buildDownloadAvatarRoute,
-  buildDownloadPublicAvatarRoute,
-  buildDeleteMemberRoute,
-  buildUpdateMemberPasswordRoute,
-} from './routes';
-import {
-  Member,
-  MemberExtra,
-  Password,
-  QueryClientConfig,
-  UUID,
-} from '../types';
+
+import { Member, MemberExtra } from '@graasp/sdk';
+
 import { DEFAULT_THUMBNAIL_SIZES, SIGNED_OUT_USER } from '../config/constants';
+import { Password, QueryClientConfig, UUID } from '../types';
 import configureAxios, {
   fallbackToPublic,
   verifyAuthentication,
 } from './axios';
+import {
+  GET_CURRENT_MEMBER_ROUTE,
+  buildDeleteMemberRoute,
+  buildDownloadAvatarRoute,
+  buildDownloadPublicAvatarRoute,
+  buildGetMember,
+  buildGetMembersBy,
+  buildGetMembersRoute,
+  buildGetPublicMember,
+  buildGetPublicMembersRoute,
+  buildPatchMember,
+  buildUpdateMemberPasswordRoute,
+  buildUploadAvatarRoute,
+} from './routes';
 
 const axios = configureAxios();
 

--- a/src/api/membership.ts
+++ b/src/api/membership.ts
@@ -1,18 +1,20 @@
+import { ItemMembership, PermissionLevel } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
-import { getMembersBy } from './member';
-import {
-  buildPostItemMembershipRoute,
-  buildEditItemMembershipRoute,
-  buildDeleteItemMembershipRoute,
-  buildGetItemMembershipsForItemsRoute,
-  buildGetPublicItemMembershipsForItemsRoute,
-  buildPostManyItemMembershipsRoute,
-} from './routes';
-import { Membership, Permission, QueryClientConfig, UUID } from '../types';
+
+import { QueryClientConfig, UUID } from '../types';
 import configureAxios, {
   fallbackToPublic,
   verifyAuthentication,
 } from './axios';
+import { getMembersBy } from './member';
+import {
+  buildDeleteItemMembershipRoute,
+  buildEditItemMembershipRoute,
+  buildGetItemMembershipsForItemsRoute,
+  buildGetPublicItemMembershipsForItemsRoute,
+  buildPostItemMembershipRoute,
+  buildPostManyItemMembershipsRoute,
+} from './routes';
 
 const axios = configureAxios();
 
@@ -29,9 +31,12 @@ export const getMembershipsForItems = async (
   );
 
 export const postManyItemMemberships = async (
-  { memberships, itemId }: { itemId: UUID; memberships: Partial<Membership>[] },
+  {
+    memberships,
+    itemId,
+  }: { itemId: UUID; memberships: Partial<ItemMembership>[] },
   config: QueryClientConfig,
-): Promise<(Membership | Error)[]> => {
+): Promise<(ItemMembership | Error)[]> => {
   const { API_HOST } = config;
 
   return verifyAuthentication(() =>
@@ -48,7 +53,7 @@ export const postItemMembership = async (
     id,
     email,
     permission,
-  }: { id: UUID; email: string; permission: Permission },
+  }: { id: UUID; email: string; permission: PermissionLevel },
   config: QueryClientConfig,
 ) => {
   const { API_HOST } = config;
@@ -70,7 +75,7 @@ export const postItemMembership = async (
 };
 
 export const editItemMembership = async (
-  { id, permission }: { id: UUID; permission: Permission },
+  { id, permission }: { id: UUID; permission: PermissionLevel },
   { API_HOST }: QueryClientConfig,
 ) =>
   verifyAuthentication(() =>

--- a/src/api/mentions.ts
+++ b/src/api/mentions.ts
@@ -1,5 +1,5 @@
-import configureAxios, { verifyAuthentication } from './axios';
 import { ChatMention, MemberMentions, QueryClientConfig, UUID } from '../types';
+import configureAxios, { verifyAuthentication } from './axios';
 import {
   buildClearMentionsRoute,
   buildDeleteMentionRoute,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,4 +1,5 @@
 import qs from 'qs';
+
 import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
 import { UUID } from '../types';
 

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -1,14 +1,14 @@
 import { QueryClientConfig } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
 import {
-  buildChangePlanRoute,
-  buildGetPlanRoute,
-  buildSetDefaultCardRoute,
   CREATE_SETUP_INTENT_ROUTE,
   GET_CARDS_ROUTE,
   GET_CURRENT_CUSTOMER,
   GET_OWN_PLAN_ROUTE,
   GET_PLANS_ROUTE,
+  buildChangePlanRoute,
+  buildGetPlanRoute,
+  buildSetDefaultCardRoute,
 } from './routes';
 
 const axios = configureAxios();

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,11 +1,4 @@
 import Cookies from 'js-cookie';
 
-export enum REQUEST_METHODS {
-  GET = 'GET',
-  POST = 'POST',
-  DELETE = 'DELETE',
-  PUT = 'PUT',
-  PATCH = 'PATCH',
-}
-
+// eslint-disable-next-line import/prefer-default-export
 export const isUserAuthenticated = () => Boolean(Cookies.get('session'));

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,4 +1,0 @@
-import Cookies from 'js-cookie';
-
-// eslint-disable-next-line import/prefer-default-export
-export const isUserAuthenticated = () => Boolean(Cookies.get('session'));

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
+
 // React Query Configs
 
 // time during which cache entry is never refetched

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -8,7 +8,6 @@ export const STALE_TIME_MILLISECONDS = 0; // default is 0 to always refetch, can
 export const CACHE_TIME_MILLISECONDS = 1000 * 60 * 5; // default is 5 min
 export const CONSTANT_KEY_CACHE_TIME_MILLISECONDS = 1000 * 60 * 15; // default is 5 min
 
-export const COOKIE_SESSION_NAME = 'session';
 export const SIGNED_OUT_USER = {};
 
 export const FALLBACK_TO_PUBLIC_FOR_STATUS_CODES = [

--- a/src/config/error.test.ts
+++ b/src/config/error.test.ts
@@ -1,5 +1,4 @@
-import { UndefinedArgument } from '../types';
-import { UserIsSignedOut } from './errors';
+import { UndefinedArgument, UserIsSignedOut } from './errors';
 
 describe('Errors', () => {
   it('Undefined Argument error', () => {

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -1,11 +1,20 @@
+// eslint-disable-next-line max-classes-per-file
 import { StatusCodes } from 'http-status-codes';
 
-// eslint-disable-next-line import/prefer-default-export
 export class UserIsSignedOut extends Error {
   code: number;
 
   constructor() {
     super('User is not authenticated');
     this.code = StatusCodes.UNAUTHORIZED;
+  }
+}
+
+export class UndefinedArgument extends Error {
+  constructor() {
+    super();
+    this.message = 'UnexpectedInput';
+    this.name = 'UnexpectedInput';
+    this.stack = new Error().stack;
   }
 }

--- a/src/hooks/action.test.ts
+++ b/src/hooks/action.test.ts
@@ -1,13 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import Cookies from 'js-cookie';
-import { mockHook, setUpTest } from '../../test/utils';
+import nock from 'nock';
+
 import {
   ACTIONS_DATA,
   ITEMS,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
 import { buildGetActions } from '../api/routes';
 import { buildActionsKey } from '../config/keys';
 import { ActionDataRecord } from '../types';

--- a/src/hooks/action.ts
+++ b/src/hooks/action.ts
@@ -1,8 +1,10 @@
 import { useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { buildActionsKey } from '../config/keys';
 import { QueryClientConfig, UUID } from '../types';
-import { convertJs } from '../utils/util';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/apps.test.ts
+++ b/src/hooks/apps.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import { List } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
+import { List } from 'immutable';
 import Cookies from 'js-cookie';
-import { buildAppListRoute } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import nock from 'nock';
+
 import { APPS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import { buildAppListRoute } from '../api/routes';
 import { APPS_KEY } from '../config/keys';
 import { AppRecord } from '../types';
 

--- a/src/hooks/apps.ts
+++ b/src/hooks/apps.ts
@@ -1,9 +1,11 @@
 import { useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
 import { APPS_KEY } from '../config/keys';
 import { QueryClientConfig } from '../types';
-import { convertJs } from '../utils/util';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/category.test.ts
+++ b/src/hooks/category.test.ts
@@ -1,29 +1,30 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import { List, Record, RecordOf } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
+import { List, Record, RecordOf } from 'immutable';
 import Cookies from 'js-cookie';
-import { mockHook, setUpTest } from '../../test/utils';
-import {
-  buildGetCategoriesRoute,
-  buildGetCategoryRoute,
-  buildGetItemCategoriesRoute,
-  buildGetItemsInCategoryRoute,
-  GET_CATEGORY_TYPES_ROUTE,
-} from '../api/routes';
-import {
-  buildCategoriesKey,
-  buildCategoryKey,
-  buildItemCategoriesKey,
-  buildItemsByCategoriesKey,
-  CATEGORY_TYPES_KEY,
-} from '../config/keys';
+import nock from 'nock';
+
 import {
   CATEGORIES,
   CATEGORY_TYPES,
   ITEM_CATEGORIES,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import {
+  GET_CATEGORY_TYPES_ROUTE,
+  buildGetCategoriesRoute,
+  buildGetCategoryRoute,
+  buildGetItemCategoriesRoute,
+  buildGetItemsInCategoryRoute,
+} from '../api/routes';
+import {
+  CATEGORY_TYPES_KEY,
+  buildCategoriesKey,
+  buildCategoryKey,
+  buildItemCategoriesKey,
+  buildItemsByCategoriesKey,
+} from '../config/keys';
 import {
   CategoryRecord,
   CategoryTypeRecord,

--- a/src/hooks/category.ts
+++ b/src/hooks/category.ts
@@ -1,15 +1,17 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig, UUID } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
+import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
 import {
-  buildCategoriesKey,
   CATEGORY_TYPES_KEY,
+  buildCategoriesKey,
   buildCategoryKey,
   buildItemCategoriesKey,
   buildItemsByCategoriesKey,
 } from '../config/keys';
-import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig, UUID } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/chat.test.ts
+++ b/src/hooks/chat.test.ts
@@ -1,15 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import { Record, RecordOf } from 'immutable';
 import Cookies from 'js-cookie';
-import { buildGetItemChatRoute } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import nock from 'nock';
+
 import {
-  buildChatMessages,
   ITEMS,
   UNAUTHORIZED_RESPONSE,
+  buildChatMessages,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import { buildGetItemChatRoute } from '../api/routes';
 import { buildItemChatKey } from '../config/keys';
 import type { ItemChat, ItemChatRecord } from '../types';
 

--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -1,10 +1,12 @@
 import { QueryClient, useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { buildItemChatKey } from '../config/keys';
 import { ItemChatRecord, QueryClientConfig, UUID } from '../types';
 import { configureWsChatHooks } from '../ws';
 import { WebsocketClient } from '../ws/ws-client';
-import { convertJs } from '../utils/util';
 
 export default (
   queryClient: QueryClient,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,21 +1,22 @@
 import { QueryClient } from 'react-query';
+
 import { QueryClientConfig } from '../types';
 import { WebsocketClient } from '../ws/ws-client';
-import configureChatHooks from './chat';
-import configureMentionsHooks from './mentions';
-import configureItemHooks from './item';
-import configureItemFlagHooks from './itemFlag';
-import configureItemTagHooks from './itemTag';
-import configureMemberHooks from './member';
+import configureActionHooks from './action';
 import configureAppsHooks from './apps';
 import configureCategoryHooks from './category';
-import configureKeywordSearchHooks from './search';
-import configureItemLikeHooks from './itemLike';
-import configureItemValidationHooks from './itemValidation';
-import configureActionHooks from './action';
+import configureChatHooks from './chat';
 import configureInvitationHooks from './invitation';
+import configureItemHooks from './item';
+import configureItemFlagHooks from './itemFlag';
+import configureItemLikeHooks from './itemLike';
+import configureItemTagHooks from './itemTag';
+import configureItemValidationHooks from './itemValidation';
+import configureMemberHooks from './member';
 import configureMembershipHooks from './membership';
+import configureMentionsHooks from './mentions';
 import configurePlanHooks from './plan';
+import configureKeywordSearchHooks from './search';
 
 export default (
   queryClient: QueryClient,

--- a/src/hooks/invitation.test.ts
+++ b/src/hooks/invitation.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
 import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import {
+  ITEMS,
+  UNAUTHORIZED_RESPONSE,
+  buildInvitationRecord,
+} from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
 import {
   buildGetInvitationRoute,
   buildGetItemInvitationsForItemRoute,
 } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
-import {
-  buildInvitationRecord,
-  ITEMS,
-  UNAUTHORIZED_RESPONSE,
-} from '../../test/constants';
 import { buildInvitationKey, buildItemInvitationsKey } from '../config/keys';
 import { InvitationRecord } from '../types';
 

--- a/src/hooks/invitation.ts
+++ b/src/hooks/invitation.ts
@@ -1,9 +1,12 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig, UndefinedArgument, UUID } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
+import { UndefinedArgument } from '../config/errors';
 import { buildInvitationKey, buildItemInvitationsKey } from '../config/keys';
 import { getInvitationRoutine } from '../routines';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig, UUID } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { notifier, defaultQueryOptions } = queryConfig;

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -1,9 +1,23 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { StatusCodes } from 'http-status-codes';
+import { List, Map } from 'immutable';
 import Cookies from 'js-cookie';
 import nock from 'nock';
-import { StatusCodes } from 'http-status-codes';
-import { Map, List } from 'immutable';
+
+import { Item, ItemType } from '@graasp/sdk';
+
 import {
+  FILE_RESPONSE,
+  ITEMS,
+  TAGS,
+  THUMBNAIL_BLOB_RESPONSE,
+  UNAUTHORIZED_RESPONSE,
+} from '../../test/constants';
+import { Endpoint, mockHook, setUpTest } from '../../test/utils';
+import {
+  GET_OWN_ITEMS_ROUTE,
+  GET_RECYCLED_ITEMS_ROUTE,
+  SHARED_ITEM_WITH_ROUTE,
   buildDownloadFilesRoute,
   buildDownloadItemThumbnailRoute,
   buildGetChildrenRoute,
@@ -13,34 +27,23 @@ import {
   buildGetPublicItemRoute,
   buildGetPublicItemsWithTag,
   buildPublicDownloadFilesRoute,
-  GET_OWN_ITEMS_ROUTE,
-  GET_RECYCLED_ITEMS_ROUTE,
-  SHARED_ITEM_WITH_ROUTE,
 } from '../api/routes';
-import { Endpoint, mockHook, setUpTest } from '../../test/utils';
+import { THUMBNAIL_SIZES } from '../config/constants';
 import {
-  FILE_RESPONSE,
-  ITEMS,
-  TAGS,
-  THUMBNAIL_BLOB_RESPONSE,
-  UNAUTHORIZED_RESPONSE,
-} from '../../test/constants';
-import {
+  OWN_ITEMS_KEY,
+  RECYCLED_ITEMS_KEY,
+  SHARED_ITEMS_KEY,
   buildFileContentKey,
   buildItemChildrenKey,
   buildItemKey,
   buildItemLoginKey,
   buildItemParentsKey,
+  buildItemThumbnailKey,
   buildItemsChildrenKey,
   buildItemsKey,
   buildPublicItemsWithTagKey,
-  buildItemThumbnailKey,
-  OWN_ITEMS_KEY,
-  RECYCLED_ITEMS_KEY,
-  SHARED_ITEMS_KEY,
 } from '../config/keys';
-import type { ItemRecord, Item, ItemLoginRecord } from '../types';
-import { THUMBNAIL_SIZES } from '../config/constants';
+import type { ItemLoginRecord, ItemRecord } from '../types';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
@@ -260,9 +263,13 @@ describe('Items Hooks', () => {
       id: 'child-item-id',
       path: [...ITEMS.map(({ id }) => id), 'child_item_id'].join('.'),
       name: 'child-item-id',
-      type: 'folder',
+      type: ItemType.FOLDER,
       description: '',
       extra: {},
+      settings: {},
+      updatedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      creator: 'creator',
     };
     const response = ITEMS;
     it(`Receive parents of item by id`, async () => {
@@ -507,7 +514,7 @@ describe('Items Hooks', () => {
     });
 
     it(`Receive two items`, async () => {
-      const response = ITEMS;
+      const response = ITEMS.slice(0, 2);
       const ids: string[] = response.map(({ id }) => id).toArray();
       const hook = () => hooks.useItems(ids);
       const route = `/${buildGetItemsRoute(ids)}`;

--- a/src/hooks/itemFlag.test.ts
+++ b/src/hooks/itemFlag.test.ts
@@ -1,12 +1,13 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
-import { GET_FLAGS_ROUTE } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
-import { FLAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
-import { ITEM_FLAGS_KEY } from '../config/keys';
 import { List } from 'immutable';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { FLAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import { GET_FLAGS_ROUTE } from '../api/routes';
+import { ITEM_FLAGS_KEY } from '../config/keys';
 import { FlagRecord } from '../types';
 
 const { hooks, wrapper, queryClient } = setUpTest();

--- a/src/hooks/itemFlag.ts
+++ b/src/hooks/itemFlag.ts
@@ -1,9 +1,11 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
-import { ITEM_FLAGS_KEY } from '../config/keys';
 import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
-import { convertJs } from '../utils/util';
+import { ITEM_FLAGS_KEY } from '../config/keys';
+import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/itemLike.test.ts
+++ b/src/hooks/itemLike.test.ts
@@ -1,17 +1,18 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
-import { buildGetLikeCountRoute, buildGetLikedItemsRoute } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import { List } from 'immutable';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
 import {
   ITEMS,
-  LIKE_COUNT,
   ITEM_LIKES,
+  LIKE_COUNT,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import { buildGetLikeCountRoute, buildGetLikedItemsRoute } from '../api/routes';
 import { buildGetLikeCountKey, buildGetLikedItemsKey } from '../config/keys';
-import { List } from 'immutable';
 import { ItemLikeRecord } from '../types';
 
 const { hooks, wrapper, queryClient } = setUpTest();

--- a/src/hooks/itemLike.ts
+++ b/src/hooks/itemLike.ts
@@ -1,8 +1,10 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig, UUID } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { buildGetLikeCountKey, buildGetLikedItemsKey } from '../config/keys';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig, UUID } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/itemTag.test.ts
+++ b/src/hooks/itemTag.test.ts
@@ -1,16 +1,17 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
-import Cookies from 'js-cookie';
 import { List, Record } from 'immutable';
-import {
-  buildGetItemsTagsRoute,
-  buildGetItemTagsRoute,
-  GET_TAGS_ROUTE,
-} from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
 import { ITEMS, TAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
-import { buildItemTagsKey, TAGS_KEY } from '../config/keys';
+import { mockHook, setUpTest } from '../../test/utils';
+import {
+  GET_TAGS_ROUTE,
+  buildGetItemTagsRoute,
+  buildGetItemsTagsRoute,
+} from '../api/routes';
+import { TAGS_KEY, buildItemTagsKey } from '../config/keys';
 import { ItemTagRecord } from '../types';
 
 const { hooks, wrapper, queryClient } = setUpTest();

--- a/src/hooks/itemTag.ts
+++ b/src/hooks/itemTag.ts
@@ -1,20 +1,18 @@
-import { QueryClient, useQuery } from 'react-query';
 import { List } from 'immutable';
+import { QueryClient, useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
 import { isError } from '@graasp/utils';
-import {
-  ItemTagRecord,
-  QueryClientConfig,
-  UndefinedArgument,
-  UUID,
-} from '../types';
+
 import * as Api from '../api';
+import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
+import { UndefinedArgument } from '../config/errors';
 import {
+  TAGS_KEY,
   buildItemTagsKey,
   buildManyItemTagsKey,
-  TAGS_KEY,
 } from '../config/keys';
-import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
-import { convertJs } from '../utils/util';
+import { ItemTagRecord, QueryClientConfig, UUID } from '../types';
 
 export default (queryConfig: QueryClientConfig, queryClient: QueryClient) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/itemValidation.test.ts
+++ b/src/hooks/itemValidation.test.ts
@@ -1,23 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import { List } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
+import { List } from 'immutable';
 import Cookies from 'js-cookie';
-import { mockHook, setUpTest } from '../../test/utils';
-import {
-  buildGetItemValidationAndReviewRoute,
-  buildGetItemValidationGroupsRoute,
-  GET_ITEM_VALIDATION_REVIEWS_ROUTE,
-  GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE,
-  GET_ITEM_VALIDATION_STATUSES_ROUTE,
-} from '../api/routes';
-import {
-  buildItemValidationAndReviewKey,
-  buildItemValidationGroupsKey,
-  ITEM_VALIDATION_REVIEWS_KEY,
-  ITEM_VALIDATION_REVIEW_STATUSES_KEY,
-  ITEM_VALIDATION_STATUSES_KEY,
-} from '../config/keys';
+import nock from 'nock';
+
 import {
   FULL_VALIDATION_RECORDS,
   ITEM_VALIDATION_GROUPS,
@@ -25,6 +11,21 @@ import {
   STATUS_LIST,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import {
+  GET_ITEM_VALIDATION_REVIEWS_ROUTE,
+  GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE,
+  GET_ITEM_VALIDATION_STATUSES_ROUTE,
+  buildGetItemValidationAndReviewRoute,
+  buildGetItemValidationGroupsRoute,
+} from '../api/routes';
+import {
+  ITEM_VALIDATION_REVIEWS_KEY,
+  ITEM_VALIDATION_REVIEW_STATUSES_KEY,
+  ITEM_VALIDATION_STATUSES_KEY,
+  buildItemValidationAndReviewKey,
+  buildItemValidationGroupsKey,
+} from '../config/keys';
 import {
   FullValidationRecordRecord,
   ItemValidationAndReviewRecord,

--- a/src/hooks/itemValidation.ts
+++ b/src/hooks/itemValidation.ts
@@ -1,14 +1,16 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig, UUID } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import {
-  buildItemValidationAndReviewKey,
-  buildItemValidationGroupsKey,
   ITEM_VALIDATION_REVIEWS_KEY,
   ITEM_VALIDATION_REVIEW_STATUSES_KEY,
   ITEM_VALIDATION_STATUSES_KEY,
+  buildItemValidationAndReviewKey,
+  buildItemValidationGroupsKey,
 } from '../config/keys';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig, UUID } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -1,23 +1,22 @@
-import { QueryClient, useQuery } from 'react-query';
 import { List } from 'immutable';
+import { QueryClient, useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
+import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
+import { UndefinedArgument } from '../config/errors';
 import {
+  CURRENT_MEMBER_KEY,
   buildAvatarKey,
   buildMemberKey,
   buildMembersKey,
-  CURRENT_MEMBER_KEY,
 } from '../config/keys';
-import {
-  MemberRecord,
-  QueryClientConfig,
-  UndefinedArgument,
-  UUID,
-} from '../types';
-import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
-import { convertJs } from '../utils/util';
+import { getMembersRoutine } from '../routines';
+import { MemberRecord, QueryClientConfig, UUID } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
-  const { defaultQueryOptions } = queryConfig;
+  const { defaultQueryOptions, notifier } = queryConfig;
 
   const useCurrentMember = () =>
     useQuery({
@@ -54,6 +53,9 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
           const { id } = member;
           queryClient.setQueryData(buildMemberKey(id), member);
         });
+      },
+      onError: (error) => {
+        notifier?.({ type: getMembersRoutine.FAILURE, payload: { error } });
       },
       ...defaultQueryOptions,
     });

--- a/src/hooks/membership.test.ts
+++ b/src/hooks/membership.test.ts
@@ -1,23 +1,24 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
-import {
-  buildGetItemMembershipsForItemsRoute,
-  buildGetPublicItemMembershipsForItemsRoute,
-} from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
 import {
   ITEMS,
   ITEM_MEMBERSHIPS_RESPONSE,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
 import {
-  buildManyItemMembershipsKey,
+  buildGetItemMembershipsForItemsRoute,
+  buildGetPublicItemMembershipsForItemsRoute,
+} from '../api/routes';
+import {
   buildItemMembershipsKey,
+  buildManyItemMembershipsKey,
 } from '../config/keys';
-import type { MembershipRecord } from '../types';
+import type { ItemMembershipRecord } from '../types';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
@@ -39,7 +40,7 @@ describe('Membership Hooks', () => {
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
 
-      expect(data as List<MembershipRecord>).toEqualImmutable(response[0]);
+      expect(data as List<ItemMembershipRecord>).toEqualImmutable(response[0]);
       // verify cache keys
       expect(queryClient.getQueryData(key)).toEqualImmutable(response[0]);
     });
@@ -84,7 +85,7 @@ describe('Membership Hooks', () => {
         wrapper,
       });
 
-      expect(data as List<MembershipRecord>).toEqualImmutable(response[0]);
+      expect(data as List<ItemMembershipRecord>).toEqualImmutable(response[0]);
       // verify cache keys
       expect(queryClient.getQueryData(key)).toEqualImmutable(response[0]);
     });
@@ -129,7 +130,7 @@ describe('Membership Hooks', () => {
       const endpoints = [{ route: oneRoute, response: oneResponse }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
 
-      expect(data as List<List<MembershipRecord>>).toEqualImmutable(
+      expect(data as List<List<ItemMembershipRecord>>).toEqualImmutable(
         oneResponse,
       );
       // verify cache keys
@@ -141,7 +142,9 @@ describe('Membership Hooks', () => {
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
 
-      expect(data as List<List<MembershipRecord>>).toEqualImmutable(response);
+      expect(data as List<List<ItemMembershipRecord>>).toEqualImmutable(
+        response,
+      );
       // verify cache keys
       expect(queryClient.getQueryData(key)).toEqualImmutable(response);
     });
@@ -184,7 +187,9 @@ describe('Membership Hooks', () => {
         wrapper,
       });
 
-      expect(data as List<List<MembershipRecord>>).toEqualImmutable(response);
+      expect(data as List<List<ItemMembershipRecord>>).toEqualImmutable(
+        response,
+      );
       // verify cache keys
       expect(queryClient.getQueryData(key)).toEqualImmutable(response);
     });

--- a/src/hooks/membership.ts
+++ b/src/hooks/membership.ts
@@ -1,17 +1,15 @@
 import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
+import { UndefinedArgument } from '../config/errors';
 import {
   buildItemMembershipsKey,
   buildManyItemMembershipsKey,
 } from '../config/keys';
-import {
-  MembershipRecord,
-  QueryClientConfig,
-  UndefinedArgument,
-  UUID,
-} from '../types';
-import { convertJs } from '../utils/util';
+import { ItemMembershipRecord, QueryClientConfig, UUID } from '../types';
 import { configureWsMembershipHooks } from '../ws';
 import { WebsocketClient } from '../ws/ws-client';
 
@@ -37,7 +35,7 @@ export default (
 
       return useQuery({
         queryKey: buildItemMembershipsKey(id),
-        queryFn: (): Promise<List<MembershipRecord>> => {
+        queryFn: (): Promise<List<ItemMembershipRecord>> => {
           if (!id) {
             throw new UndefinedArgument();
           }
@@ -61,7 +59,7 @@ export default (
 
       return useQuery({
         queryKey: buildManyItemMembershipsKey(ids),
-        queryFn: (): Promise<List<List<MembershipRecord>>> => {
+        queryFn: (): Promise<List<List<ItemMembershipRecord>>> => {
           if (!ids) {
             throw new UndefinedArgument();
           }
@@ -70,12 +68,12 @@ export default (
             convertJs(data),
           );
         },
-        onSuccess: async (memberships: List<List<MembershipRecord>>) => {
+        onSuccess: async (memberships: List<List<ItemMembershipRecord>>) => {
           // save memberships in their own key
           ids?.forEach(async (id, idx) => {
             queryClient.setQueryData(
               buildItemMembershipsKey(id),
-              memberships.get(idx) as List<MembershipRecord>,
+              memberships.get(idx) as List<ItemMembershipRecord>,
             );
           });
         },

--- a/src/hooks/mentions.test.ts
+++ b/src/hooks/mentions.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
 import Cookies from 'js-cookie';
-import {
-  buildGetMemberMentionsRoute,
-  GET_CURRENT_MEMBER_ROUTE,
-} from '../api/routes';
+import nock from 'nock';
+
+import { MEMBER_RESPONSE, buildMemberMentions } from '../../test/constants';
 import { mockHook, setUpTest } from '../../test/utils';
-import { buildMemberMentions, MEMBER_RESPONSE } from '../../test/constants';
+import {
+  GET_CURRENT_MEMBER_ROUTE,
+  buildGetMemberMentionsRoute,
+} from '../api/routes';
 import { buildMentionKey } from '../config/keys';
 import type { MemberMentionsRecord } from '../types';
 

--- a/src/hooks/mentions.ts
+++ b/src/hooks/mentions.ts
@@ -1,11 +1,13 @@
-import { QueryClient, useQuery, UseQueryResult } from 'react-query';
+import { Record } from 'immutable';
+import { QueryClient, UseQueryResult, useQuery } from 'react-query';
+
+import { Member, convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { buildMentionKey } from '../config/keys';
-import { Member, MemberMentionsRecord, QueryClientConfig } from '../types';
-import { WebsocketClient } from '../ws/ws-client';
+import { MemberMentionsRecord, QueryClientConfig } from '../types';
 import { configureWsChatMentionsHooks } from '../ws';
-import { Record } from 'immutable';
-import { convertJs } from '../utils/util';
+import { WebsocketClient } from '../ws/ws-client';
 
 export default (
   queryClient: QueryClient,

--- a/src/hooks/plan.ts
+++ b/src/hooks/plan.ts
@@ -1,14 +1,16 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import {
-  buildPlanKey,
   CARDS_KEY,
   CURRENT_CUSTOMER_KEY,
   OWN_PLAN_KEY,
   PLANS_KEY,
+  buildPlanKey,
 } from '../config/keys';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions: defaultOptions } = queryConfig;

--- a/src/hooks/search.test.ts
+++ b/src/hooks/search.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import Cookies from 'js-cookie';
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
-import { buildGetItemsByKeywordRoute } from '../api/routes';
-import { mockHook, setUpTest } from '../../test/utils';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
 import { ITEMS, Ranges, UNAUTHORIZED_RESPONSE } from '../../test/constants';
+import { mockHook, setUpTest } from '../../test/utils';
+import { buildGetItemsByKeywordRoute } from '../api/routes';
 import { buildSearchByKeywordKey } from '../config/keys';
 import { ItemRecord } from '../types';
 

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -1,8 +1,10 @@
 import { useQuery } from 'react-query';
-import { QueryClientConfig } from '../types';
+
+import { convertJs } from '@graasp/sdk';
+
 import * as Api from '../api';
 import { buildSearchByKeywordKey } from '../config/keys';
-import { convertJs } from '../utils/util';
+import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/mutations/action.test.ts
+++ b/src/mutations/action.test.ts
@@ -1,17 +1,19 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
-import { buildExportActions } from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod } from '@graasp/sdk';
+
 import {
   ITEMS,
   OK_RESPONSE,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import { buildExportActions } from '../api/routes';
 import { MUTATION_KEYS } from '../config/keys';
-import { REQUEST_METHODS } from '../api/utils';
 import { exportActionsRoutine } from '../routines';
 
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
@@ -35,7 +37,7 @@ describe('Action Mutations', () => {
 
     it(`Export Actions`, async () => {
       const endpoints = [
-        { route, response: OK_RESPONSE, method: REQUEST_METHODS.POST },
+        { route, response: OK_RESPONSE, method: HttpMethod.POST },
       ];
 
       const mockedMutation = await mockMutation({
@@ -61,7 +63,7 @@ describe('Action Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];

--- a/src/mutations/action.ts
+++ b/src/mutations/action.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from 'react-query';
+
 import { exportActions } from '../api';
 import { MUTATION_KEYS } from '../config/keys';
 import { exportActionsRoutine } from '../routines';

--- a/src/mutations/authentication.test.ts
+++ b/src/mutations/authentication.test.ts
@@ -1,25 +1,27 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import Cookies from 'js-cookie';
-import * as utils from '@graasp/utils';
-import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { StatusCodes } from 'http-status-codes';
-import {
-  buildUpdateMemberPasswordRoute,
-  SIGN_IN_ROUTE,
-  SIGN_IN_WITH_PASSWORD_ROUTE,
-  SIGN_OUT_ROUTE,
-  SIGN_UP_ROUTE,
-} from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+import * as utils from '@graasp/utils';
+
 import {
   DOMAIN,
   OK_RESPONSE,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import {
+  SIGN_IN_ROUTE,
+  SIGN_IN_WITH_PASSWORD_ROUTE,
+  SIGN_OUT_ROUTE,
+  SIGN_UP_ROUTE,
+  buildUpdateMemberPasswordRoute,
+} from '../api/routes';
 import { CURRENT_MEMBER_KEY, MUTATION_KEYS } from '../config/keys';
-import { REQUEST_METHODS } from '../api/utils';
 import {
   signInRoutine,
   signInWithPasswordRoutine,
@@ -52,7 +54,7 @@ describe('Authentication Mutations', () => {
 
     it(`Sign in`, async () => {
       const endpoints = [
-        { route, response: OK_RESPONSE, method: REQUEST_METHODS.POST },
+        { route, response: OK_RESPONSE, method: HttpMethod.POST },
       ];
 
       const mockedMutation = await mockMutation({
@@ -77,7 +79,7 @@ describe('Authentication Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];
@@ -113,7 +115,7 @@ describe('Authentication Mutations', () => {
           route,
           response: { resource: link },
           statusCode: StatusCodes.SEE_OTHER,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
         },
       ];
       // set random data in cache
@@ -144,7 +146,7 @@ describe('Authentication Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];
@@ -182,7 +184,7 @@ describe('Authentication Mutations', () => {
           route,
           response: { email, id, name },
           statusCode: StatusCodes.OK,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
         },
       ];
 
@@ -208,7 +210,7 @@ describe('Authentication Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];
@@ -239,7 +241,7 @@ describe('Authentication Mutations', () => {
 
     it(`Sign up`, async () => {
       const endpoints = [
-        { route, response: OK_RESPONSE, method: REQUEST_METHODS.POST },
+        { route, response: OK_RESPONSE, method: HttpMethod.POST },
       ];
 
       const mockedMutation = await mockMutation({
@@ -264,7 +266,7 @@ describe('Authentication Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];
@@ -298,7 +300,7 @@ describe('Authentication Mutations', () => {
       queryClient.setQueryData(CURRENT_MEMBER_KEY, 'somevalue');
 
       const endpoints = [
-        { route, response: OK_RESPONSE, method: REQUEST_METHODS.GET },
+        { route, response: OK_RESPONSE, method: HttpMethod.GET },
       ];
 
       const mockedMutation = await mockMutation({
@@ -330,7 +332,7 @@ describe('Authentication Mutations', () => {
         {
           route,
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           statusCode: StatusCodes.UNAUTHORIZED,
         },
       ];

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -1,21 +1,23 @@
 import { QueryClient } from 'react-query';
+
 import { SUCCESS_MESSAGES } from '@graasp/translations';
 import {
-  removeSession,
   getStoredSessions,
-  setCurrentSession,
+  removeSession,
   saveUrlForRedirection,
+  setCurrentSession,
 } from '@graasp/utils';
+
 import * as Api from '../api';
+import { CURRENT_MEMBER_KEY, MUTATION_KEYS } from '../config/keys';
 import {
-  signOutRoutine,
   signInRoutine,
   signInWithPasswordRoutine,
+  signOutRoutine,
   signUpRoutine,
   switchMemberRoutine,
   updatePasswordRoutine,
 } from '../routines';
-import { CURRENT_MEMBER_KEY, MUTATION_KEYS } from '../config/keys';
 import { QueryClientConfig, UUID } from '../types';
 import { isServer } from '../utils/util';
 

--- a/src/mutations/chat.test.ts
+++ b/src/mutations/chat.test.ts
@@ -1,24 +1,26 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import {
+  ITEMS,
+  ITEM_CHAT,
+  MESSAGE_IDS,
+  OK_RESPONSE,
+  UNAUTHORIZED_RESPONSE,
+} from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
   buildClearItemChatRoute,
   buildDeleteItemChatMessageRoute,
   buildPatchItemChatMessageRoute,
   buildPostItemChatMessageRoute,
 } from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
-import {
-  ITEMS,
-  ITEM_CHAT,
-  OK_RESPONSE,
-  UNAUTHORIZED_RESPONSE,
-  MESSAGE_IDS,
-} from '../../test/constants';
-import { buildItemChatKey, MUTATION_KEYS } from '../config/keys';
-import { REQUEST_METHODS } from '../api/utils';
+import { MUTATION_KEYS, buildItemChatKey } from '../config/keys';
 import {
   clearItemChatRoutine,
   deleteItemChatMessageRoutine,
@@ -51,7 +53,7 @@ describe('Chat Mutations', () => {
 
       it(`Post item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.POST },
+          { route, response: OK_RESPONSE, method: HttpMethod.POST },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -76,7 +78,7 @@ describe('Chat Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.POST,
+            method: HttpMethod.POST,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -110,7 +112,7 @@ describe('Chat Mutations', () => {
 
       it(`Patch item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.PATCH },
+          { route, response: OK_RESPONSE, method: HttpMethod.PATCH },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -139,7 +141,7 @@ describe('Chat Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.PATCH,
+            method: HttpMethod.PATCH,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -178,7 +180,7 @@ describe('Chat Mutations', () => {
 
       it(`Delete item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.DELETE },
+          { route, response: OK_RESPONSE, method: HttpMethod.DELETE },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -203,7 +205,7 @@ describe('Chat Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -237,7 +239,7 @@ describe('Chat Mutations', () => {
 
       it(`Clear chat`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.DELETE },
+          { route, response: OK_RESPONSE, method: HttpMethod.DELETE },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -262,7 +264,7 @@ describe('Chat Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -306,7 +308,7 @@ describe('Chat Mutations', () => {
       const mutation = () => useMutation(MUTATION_KEYS.POST_ITEM_CHAT_MESSAGE);
       it(`Post item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.POST },
+          { route, response: OK_RESPONSE, method: HttpMethod.POST },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -332,7 +334,7 @@ describe('Chat Mutations', () => {
       const mutation = () => useMutation(MUTATION_KEYS.PATCH_ITEM_CHAT_MESSAGE);
       it(`Patch item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.PATCH },
+          { route, response: OK_RESPONSE, method: HttpMethod.PATCH },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -359,7 +361,7 @@ describe('Chat Mutations', () => {
         useMutation(MUTATION_KEYS.DELETE_ITEM_CHAT_MESSAGE);
       it(`Delete item chat message`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.DELETE },
+          { route, response: OK_RESPONSE, method: HttpMethod.DELETE },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);
@@ -385,7 +387,7 @@ describe('Chat Mutations', () => {
       const mutation = () => useMutation(MUTATION_KEYS.CLEAR_ITEM_CHAT);
       it(`Clear chat`, async () => {
         const endpoints = [
-          { route, response: OK_RESPONSE, method: REQUEST_METHODS.DELETE },
+          { route, response: OK_RESPONSE, method: HttpMethod.DELETE },
         ];
         // set random data in cache
         queryClient.setQueryData(chatKey, ITEM_CHAT);

--- a/src/mutations/chat.ts
+++ b/src/mutations/chat.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
-import { buildItemChatKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildItemChatKey } from '../config/keys';
 import {
   clearItemChatRoutine,
   deleteItemChatMessageRoutine,

--- a/src/mutations/index.ts
+++ b/src/mutations/index.ts
@@ -1,22 +1,23 @@
 import { QueryClient } from 'react-query';
-import itemMutations from './item';
-import memberMutations from './member';
-import tagsMutations from './itemTag';
-import flagsMutations from './itemFlag';
-import itemLoginMutations from './itemLogin';
-import itemMembershipMutations from './membership';
-import chatMutations from './chat';
-import mentionMutations from './mentions';
-import itemCategoryMutations from './itemCategory';
-import subscriptionMutations from './plan';
+
 import { QueryClientConfig } from '../types';
-import itemExportMutations from './itemExport';
-import itemLikeMutations from './itemLike';
-import itemValidationMutations from './itemValidation';
 import actionMutations from './action';
-import invitationMutations from './invitation';
 import authenticationMutations from './authentication';
+import chatMutations from './chat';
+import invitationMutations from './invitation';
+import itemMutations from './item';
+import itemCategoryMutations from './itemCategory';
+import itemExportMutations from './itemExport';
+import flagsMutations from './itemFlag';
+import itemLikeMutations from './itemLike';
+import itemLoginMutations from './itemLogin';
 import itemPublishMutations from './itemPublish';
+import tagsMutations from './itemTag';
+import itemValidationMutations from './itemValidation';
+import memberMutations from './member';
+import itemMembershipMutations from './membership';
+import mentionMutations from './mentions';
+import subscriptionMutations from './plan';
 
 const configureMutations = (
   queryClient: QueryClient,

--- a/src/mutations/invitation.test.ts
+++ b/src/mutations/invitation.test.ts
@@ -1,26 +1,28 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import {
+  ITEMS,
+  OK_RESPONSE,
+  UNAUTHORIZED_RESPONSE,
+  buildInvitation,
+  buildInvitationRecord,
+  buildMockInvitations,
+} from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
   buildDeleteInvitationRoute,
   buildPatchInvitationRoute,
   buildPostInvitationsRoute,
   buildResendInvitationRoute,
 } from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
-import {
-  buildInvitation,
-  buildInvitationRecord,
-  buildMockInvitations,
-  ITEMS,
-  OK_RESPONSE,
-  UNAUTHORIZED_RESPONSE,
-} from '../../test/constants';
-import { buildItemInvitationsKey, MUTATION_KEYS } from '../config/keys';
-import { REQUEST_METHODS } from '../api/utils';
+import { MUTATION_KEYS, buildItemInvitationsKey } from '../config/keys';
 import {
   deleteInvitationRoutine,
   patchInvitationRoutine,
@@ -63,7 +65,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -99,7 +101,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -130,7 +132,7 @@ describe('Invitations Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -164,7 +166,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response: [newInvitationRecord, UNAUTHORIZED_RESPONSE],
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -214,7 +216,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -246,7 +248,7 @@ describe('Invitations Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -297,7 +299,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -335,7 +337,7 @@ describe('Invitations Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -379,7 +381,7 @@ describe('Invitations Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -405,7 +407,7 @@ describe('Invitations Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];

--- a/src/mutations/invitation.ts
+++ b/src/mutations/invitation.ts
@@ -1,13 +1,14 @@
 import { List } from 'immutable';
 import { QueryClient } from 'react-query';
+
 import {
-  postInvitations,
-  patchInvitation,
   deleteInvitation,
+  patchInvitation,
+  postInvitations,
   resendInvitation,
 } from '../api';
 import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
-import { buildItemInvitationsKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildItemInvitationsKey } from '../config/keys';
 import {
   deleteInvitationRoutine,
   patchInvitationRoutine,

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -1,10 +1,20 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import { SUCCESS_MESSAGES } from '@graasp/translations';
-import Cookies from 'js-cookie';
-import { List } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
+import { List } from 'immutable';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { GraaspError, HttpMethod, Item, ItemType } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
+import {
+  ITEMS,
+  OK_RESPONSE,
+  THUMBNAIL_BLOB_RESPONSE,
+  UNAUTHORIZED_RESPONSE,
+} from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
   buildCopyItemRoute,
   buildCopyItemsRoute,
@@ -20,35 +30,27 @@ import {
   buildRestoreItemsRoute,
   buildUploadItemThumbnailRoute,
 } from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
-import { REQUEST_METHODS } from '../api/utils';
+import { THUMBNAIL_SIZES } from '../config/constants';
 import {
-  OK_RESPONSE,
-  ITEMS,
-  UNAUTHORIZED_RESPONSE,
-  THUMBNAIL_BLOB_RESPONSE,
-} from '../../test/constants';
-import {
+  MUTATION_KEYS,
+  OWN_ITEMS_KEY,
+  RECYCLED_ITEMS_KEY,
   buildItemChildrenKey,
   buildItemKey,
   buildItemThumbnailKey,
   getKeyForParentId,
-  MUTATION_KEYS,
-  OWN_ITEMS_KEY,
-  RECYCLED_ITEMS_KEY,
 } from '../config/keys';
-import { GraaspError, Item, ItemRecord, ITEM_TYPES } from '../types';
-import {
-  buildPath,
-  getDirectParentId,
-  transformIdForPath,
-} from '../utils/item';
 import {
   deleteItemsRoutine,
   uploadFileRoutine,
   uploadItemThumbnailRoutine,
 } from '../routines';
-import { THUMBNAIL_SIZES } from '../config/constants';
+import { ItemRecord } from '../types';
+import {
+  buildPath,
+  getDirectParentId,
+  transformIdForPath,
+} from '../utils/item';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -66,7 +68,7 @@ describe('Items Mutations', () => {
   describe(MUTATION_KEYS.POST_ITEM, () => {
     const newItem = {
       name: 'new item',
-      type: ITEM_TYPES.FOLDER,
+      type: ItemType.FOLDER,
     };
 
     it('Post item in root', async () => {
@@ -79,7 +81,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -117,7 +119,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostItemRoute(parentItem.id)}`,
         },
       ];
@@ -150,7 +152,7 @@ describe('Items Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -188,7 +190,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -229,7 +231,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -260,7 +262,7 @@ describe('Items Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -306,7 +308,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -348,7 +350,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -400,7 +402,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -442,7 +444,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -497,7 +499,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -541,7 +543,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -592,7 +594,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -642,7 +644,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -702,7 +704,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -753,7 +755,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -803,7 +805,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -861,7 +863,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -914,7 +916,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -968,7 +970,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1018,7 +1020,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1069,7 +1071,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1123,7 +1125,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1178,7 +1180,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1232,7 +1234,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1286,7 +1288,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1343,7 +1345,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1398,7 +1400,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1462,7 +1464,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1503,7 +1505,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1567,7 +1569,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1608,7 +1610,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -1737,7 +1739,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1798,7 +1800,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1852,7 +1854,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1908,7 +1910,7 @@ describe('Items Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -1951,7 +1953,7 @@ describe('Items Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -1,43 +1,39 @@
 import { List, Record } from 'immutable';
 import { QueryClient } from 'react-query';
+
+import { GraaspError, Item, convertJs } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import * as Api from '../api';
+import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
+import { THUMBNAIL_SIZES } from '../config/constants';
+import {
+  MUTATION_KEYS,
+  OWN_ITEMS_KEY,
+  RECYCLED_ITEMS_KEY,
+  buildItemChildrenKey,
+  buildItemKey,
+  buildItemThumbnailKey,
+  getKeyForParentId,
+} from '../config/keys';
 import {
   copyItemRoutine,
   copyItemsRoutine,
   createItemRoutine,
-  deleteItemsRoutine,
   deleteItemRoutine,
+  deleteItemsRoutine,
   editItemRoutine,
+  importH5PRoutine,
+  importZipRoutine,
   moveItemRoutine,
   moveItemsRoutine,
-  uploadFileRoutine,
   recycleItemsRoutine,
   restoreItemsRoutine,
+  uploadFileRoutine,
   uploadItemThumbnailRoutine,
-  importZipRoutine,
-  importH5PRoutine,
 } from '../routines';
-import {
-  buildItemChildrenKey,
-  buildItemKey,
-  getKeyForParentId,
-  MUTATION_KEYS,
-  OWN_ITEMS_KEY,
-  RECYCLED_ITEMS_KEY,
-  buildItemThumbnailKey,
-} from '../config/keys';
+import type { ItemRecord, QueryClientConfig, UUID } from '../types';
 import { buildPath, getDirectParentId } from '../utils/item';
-import type {
-  GraaspError,
-  Item,
-  ItemRecord,
-  QueryClientConfig,
-  UUID,
-} from '../types';
-import { THUMBNAIL_SIZES } from '../config/constants';
-import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
-import { convertJs } from '../utils/util';
 
 const {
   POST_ITEM,

--- a/src/mutations/itemCategory.test.ts
+++ b/src/mutations/itemCategory.test.ts
@@ -1,21 +1,23 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import Cookies from 'js-cookie';
-import { act } from 'react-test-renderer';
 import { StatusCodes } from 'http-status-codes';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
+
+import { ITEM_CATEGORIES, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
-import { REQUEST_METHODS } from '../api/utils';
-import { buildItemCategoriesKey, MUTATION_KEYS } from '../config/keys';
 import {
   buildDeleteItemCategoryRoute,
   buildPostItemCategoryRoute,
 } from '../api/routes';
+import { MUTATION_KEYS, buildItemCategoriesKey } from '../config/keys';
 import {
   deleteItemCategoryRoutine,
   postItemCategoryRoutine,
 } from '../routines';
-import { ITEM_CATEGORIES, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -43,7 +45,7 @@ describe('Item Category Mutations', () => {
       const endpoints = [
         {
           response: { itemId: 'item-id', categoryId: 'new-category' },
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -74,7 +76,7 @@ describe('Item Category Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -115,7 +117,7 @@ describe('Item Category Mutations', () => {
       const endpoints = [
         {
           response: { itemId: 'item-id' },
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -147,7 +149,7 @@ describe('Item Category Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];

--- a/src/mutations/itemCategory.ts
+++ b/src/mutations/itemCategory.ts
@@ -1,7 +1,9 @@
-import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { QueryClient } from 'react-query';
+
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import * as Api from '../api';
-import { buildItemCategoriesKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildItemCategoriesKey } from '../config/keys';
 import {
   deleteItemCategoryRoutine,
   postItemCategoryRoutine,

--- a/src/mutations/itemExport.test.ts
+++ b/src/mutations/itemExport.test.ts
@@ -1,17 +1,19 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import Cookies from 'js-cookie';
-import { act } from 'react-test-renderer';
 import { StatusCodes } from 'http-status-codes';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import { UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
-import { REQUEST_METHODS } from '../api/utils';
-import { MUTATION_KEYS } from '../config/keys';
 import {
   buildExportItemRoute,
   buildExportPublicItemRoute,
 } from '../api/routes';
+import { MUTATION_KEYS } from '../config/keys';
 import { exportItemRoutine } from '../routines';
-import { UNAUTHORIZED_RESPONSE } from '../../test/constants';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -35,7 +37,7 @@ describe('Export Zip', () => {
       const endpoints = [
         {
           response: { id: 'id', content: 'content' },
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route,
         },
       ];
@@ -65,7 +67,7 @@ describe('Export Zip', () => {
         },
         {
           response: { id: 'id', content: 'content' },
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildExportPublicItemRoute(itemId)}`,
         },
       ];
@@ -90,7 +92,7 @@ describe('Export Zip', () => {
       const endpoints = [
         {
           response: { id: 'id', content: 'public content' },
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildExportPublicItemRoute(itemId)}`,
         },
       ];

--- a/src/mutations/itemExport.ts
+++ b/src/mutations/itemExport.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
 import { MUTATION_KEYS } from '../config/keys';
 import { exportItemRoutine } from '../routines';

--- a/src/mutations/itemFlag.test.ts
+++ b/src/mutations/itemFlag.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { StatusCodes } from 'http-status-codes';
 import Cookies from 'js-cookie';
 import nock from 'nock';
 import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import { FLAGS, ITEMS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildPostItemFlagRoute } from '../api/routes';
-import { REQUEST_METHODS } from '../api/utils';
-import { buildItemFlagsKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildItemFlagsKey } from '../config/keys';
 import { postItemFlagRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -38,7 +40,7 @@ describe('Item Flag Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -67,7 +69,7 @@ describe('Item Flag Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];

--- a/src/mutations/itemFlag.ts
+++ b/src/mutations/itemFlag.ts
@@ -1,8 +1,10 @@
-import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { QueryClient } from 'react-query';
-import { buildItemFlagsKey, MUTATION_KEYS } from '../config/keys';
-import { postItemFlagRoutine } from '../routines';
+
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import * as Api from '../api';
+import { MUTATION_KEYS, buildItemFlagsKey } from '../config/keys';
+import { postItemFlagRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {

--- a/src/mutations/itemLike.test.ts
+++ b/src/mutations/itemLike.test.ts
@@ -3,6 +3,9 @@ import { StatusCodes } from 'http-status-codes';
 import Cookies from 'js-cookie';
 import nock from 'nock';
 import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+
 import {
   ITEMS,
   ITEM_LIKES,
@@ -14,11 +17,10 @@ import {
   buildDeleteItemLikeRoute,
   buildPostItemLikeRoute,
 } from '../api/routes';
-import { REQUEST_METHODS } from '../api/utils';
 import {
+  MUTATION_KEYS,
   buildGetLikeCountKey,
   buildGetLikedItemsKey,
-  MUTATION_KEYS,
 } from '../config/keys';
 import { deleteItemLikeRoutine, postItemLikeRoutine } from '../routines';
 
@@ -51,7 +53,7 @@ describe('Item Like Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -83,7 +85,7 @@ describe('Item Like Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -125,7 +127,7 @@ describe('Item Like Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -157,7 +159,7 @@ describe('Item Like Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];

--- a/src/mutations/itemLike.ts
+++ b/src/mutations/itemLike.ts
@@ -1,9 +1,10 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
 import {
+  MUTATION_KEYS,
   buildGetLikeCountKey,
   buildGetLikedItemsKey,
-  MUTATION_KEYS,
 } from '../config/keys';
 import { deleteItemLikeRoutine, postItemLikeRoutine } from '../routines';
 import { QueryClientConfig } from '../types';

--- a/src/mutations/itemLogin.test.ts
+++ b/src/mutations/itemLogin.test.ts
@@ -1,9 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { StatusCodes } from 'http-status-codes';
-import nock from 'nock';
 import Cookies from 'js-cookie';
-import { SUCCESS_MESSAGES } from '@graasp/translations';
+import nock from 'nock';
 import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import {
   ITEMS,
   ITEM_LOGIN_RESPONSE,
@@ -14,12 +17,11 @@ import {
   buildPostItemLoginSignInRoute,
   buildPutItemLoginSchema,
 } from '../api/routes';
-import { REQUEST_METHODS } from '../api/utils';
 import {
-  buildItemLoginKey,
   CURRENT_MEMBER_KEY,
   MUTATION_KEYS,
   OWN_ITEMS_KEY,
+  buildItemLoginKey,
 } from '../config/keys';
 import { postItemLoginRoutine, putItemLoginRoutine } from '../routines';
 import { ITEM_LOGIN_SCHEMAS } from '../types';
@@ -49,7 +51,7 @@ describe('Item Login Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -83,7 +85,7 @@ describe('Item Login Mutations', () => {
         {
           response: {},
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -129,7 +131,7 @@ describe('Item Login Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.PUT,
+          method: HttpMethod.PUT,
           route,
         },
       ];
@@ -162,7 +164,7 @@ describe('Item Login Mutations', () => {
         {
           response: {},
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PUT,
+          method: HttpMethod.PUT,
           route,
         },
       ];

--- a/src/mutations/itemLogin.ts
+++ b/src/mutations/itemLogin.ts
@@ -1,8 +1,10 @@
 import { QueryClient } from 'react-query';
+
 import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import * as Api from '../api';
-import { putItemLoginRoutine, postItemLoginRoutine } from '../routines';
 import { MUTATION_KEYS, buildItemLoginKey } from '../config/keys';
+import { postItemLoginRoutine, putItemLoginRoutine } from '../routines';
 import type { QueryClientConfig } from '../types';
 
 const { POST_ITEM_LOGIN, PUT_ITEM_LOGIN } = MUTATION_KEYS;

--- a/src/mutations/itemPublish.test.ts
+++ b/src/mutations/itemPublish.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import Cookies from 'js-cookie';
-import { act } from 'react-test-renderer';
 import { StatusCodes } from 'http-status-codes';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
-import { REQUEST_METHODS } from '../api/utils';
-import { buildItemTagsKey, MUTATION_KEYS } from '../config/keys';
-import { buildItemPublishRoute } from '../api/routes';
-import { publishItemRoutine } from '../routines';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+
 import { ITEMS, ITEM_TAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import { buildItemPublishRoute } from '../api/routes';
+import { MUTATION_KEYS, buildItemTagsKey } from '../config/keys';
+import { publishItemRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -37,7 +39,7 @@ describe('Publish Item', () => {
       const endpoints = [
         {
           response: { item },
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route,
         },
       ];
@@ -70,7 +72,7 @@ describe('Publish Item', () => {
       const endpoints = [
         {
           response: { item },
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route,
         },
       ];
@@ -103,7 +105,7 @@ describe('Publish Item', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route,
         },
       ];

--- a/src/mutations/itemPublish.ts
+++ b/src/mutations/itemPublish.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
 import { MUTATION_KEYS, buildItemTagsKey } from '../config/keys';
 import { publishItemRoutine } from '../routines';

--- a/src/mutations/itemTag.test.ts
+++ b/src/mutations/itemTag.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { StatusCodes } from 'http-status-codes';
-import nock from 'nock';
 import { List } from 'immutable';
-import { SUCCESS_MESSAGES } from '@graasp/translations';
-import { act } from 'react-test-renderer';
 import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import {
   ITEMS,
   ITEM_TAGS,
@@ -13,8 +16,7 @@ import {
 } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildDeleteItemTagRoute, buildPostItemTagRoute } from '../api/routes';
-import { REQUEST_METHODS } from '../api/utils';
-import { buildItemTagsKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildItemTagsKey } from '../config/keys';
 import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
 import { ItemTagRecord } from '../types';
 
@@ -46,7 +48,7 @@ describe('Item Tag Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -81,7 +83,7 @@ describe('Item Tag Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -125,7 +127,7 @@ describe('Item Tag Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -159,7 +161,7 @@ describe('Item Tag Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];

--- a/src/mutations/itemTag.ts
+++ b/src/mutations/itemTag.ts
@@ -1,9 +1,11 @@
-import { QueryClient } from 'react-query';
 import { List } from 'immutable';
+import { QueryClient } from 'react-query';
+
 import { SUCCESS_MESSAGES } from '@graasp/translations';
-import { buildItemTagsKey, MUTATION_KEYS } from '../config/keys';
-import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
+
 import * as Api from '../api';
+import { MUTATION_KEYS, buildItemTagsKey } from '../config/keys';
+import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
 import { ItemTagRecord, QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {

--- a/src/mutations/itemValidation.test.ts
+++ b/src/mutations/itemValidation.test.ts
@@ -1,29 +1,31 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import Cookies from 'js-cookie';
-import { act } from 'react-test-renderer';
-import { List } from 'immutable';
 import { StatusCodes } from 'http-status-codes';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
-import { REQUEST_METHODS } from '../api/utils';
-import {
-  buildItemValidationAndReviewKey,
-  ITEM_VALIDATION_REVIEWS_KEY,
-  MUTATION_KEYS,
-} from '../config/keys';
-import {
-  buildPostItemValidationRoute,
-  buildUpdateItemValidationReviewRoute,
-} from '../api/routes';
-import {
-  postItemValidationRoutine,
-  updateItemValidationReviewRoutine,
-} from '../routines';
+import { List } from 'immutable';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod } from '@graasp/sdk';
+
 import {
   FULL_VALIDATION_RECORDS,
   ITEM_VALIDATION_STATUS,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import {
+  buildPostItemValidationRoute,
+  buildUpdateItemValidationReviewRoute,
+} from '../api/routes';
+import {
+  ITEM_VALIDATION_REVIEWS_KEY,
+  MUTATION_KEYS,
+  buildItemValidationAndReviewKey,
+} from '../config/keys';
+import {
+  postItemValidationRoutine,
+  updateItemValidationReviewRoutine,
+} from '../routines';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -50,7 +52,7 @@ describe('Item Validation Mutations', () => {
       const endpoints = [
         {
           response: { itemId },
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -79,7 +81,7 @@ describe('Item Validation Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -122,7 +124,7 @@ describe('Item Validation Mutations', () => {
         {
           // just for test, real response is of ItemValidationReview object
           response: { id: 'entry-id', itemId: 'item-id', statusId: 'status' },
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -160,7 +162,7 @@ describe('Item Validation Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];

--- a/src/mutations/itemValidation.ts
+++ b/src/mutations/itemValidation.ts
@@ -1,9 +1,10 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
 import {
-  buildItemValidationAndReviewKey,
   ITEM_VALIDATION_REVIEWS_KEY,
   MUTATION_KEYS,
+  buildItemValidationAndReviewKey,
 } from '../config/keys';
 import {
   postItemValidationRoutine,

--- a/src/mutations/member.test.ts
+++ b/src/mutations/member.test.ts
@@ -1,32 +1,34 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { StatusCodes } from 'http-status-codes';
 import { act } from '@testing-library/react-hooks';
+import { StatusCodes } from 'http-status-codes';
 import { List, Record } from 'immutable';
-import nock from 'nock';
 import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
-import {
-  buildDeleteMemberRoute,
-  buildPatchMember,
-  buildUploadAvatarRoute,
-  SIGN_OUT_ROUTE,
-} from '../api/routes';
-import { setUpTest, mockMutation, waitForMutation } from '../../test/utils';
+
 import {
   AVATAR_BLOB_RESPONSE,
   MEMBER_RESPONSE,
   OK_RESPONSE,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
-  buildAvatarKey,
+  SIGN_OUT_ROUTE,
+  buildDeleteMemberRoute,
+  buildPatchMember,
+  buildUploadAvatarRoute,
+} from '../api/routes';
+import { THUMBNAIL_SIZES } from '../config/constants';
+import {
   CURRENT_MEMBER_KEY,
   MUTATION_KEYS,
+  buildAvatarKey,
 } from '../config/keys';
-import { MemberRecord } from '../types';
-import { REQUEST_METHODS } from '../api/utils';
-import { THUMBNAIL_SIZES } from '../config/constants';
 import { addFavoriteItemRoutine, uploadAvatarRoutine } from '../routines';
+import { MemberRecord } from '../types';
 
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
 
@@ -69,7 +71,7 @@ describe('Member Mutations', () => {
       queryClient.setQueryData(CURRENT_MEMBER_KEY, MEMBER_RESPONSE);
       const endpoints = [
         {
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
           route,
@@ -102,7 +104,7 @@ describe('Member Mutations', () => {
       const endpoints = [
         {
           route: `/${buildDeleteMemberRoute(memberId)}`,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           response: OK_RESPONSE,
         },
         {
@@ -133,7 +135,7 @@ describe('Member Mutations', () => {
       queryClient.setQueryData(CURRENT_MEMBER_KEY, MEMBER_RESPONSE);
       const endpoints = [
         {
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
           route: `/${buildDeleteMemberRoute(memberId)}`,
@@ -171,7 +173,7 @@ describe('Member Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -200,7 +202,7 @@ describe('Member Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -242,7 +244,7 @@ describe('Member Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -285,7 +287,7 @@ describe('Member Mutations', () => {
         {
           response,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -332,7 +334,7 @@ describe('Member Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -368,7 +370,7 @@ describe('Member Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -408,7 +410,7 @@ describe('Member Mutations', () => {
       const endpoints = [
         {
           response,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -437,7 +439,7 @@ describe('Member Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];

--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -1,12 +1,11 @@
-import Cookies from 'js-cookie';
 import { QueryClient } from 'react-query';
 
-import { convertJs } from '@graasp/sdk';
+import { convertJs, removeSession, setCurrentSession } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
 
 import * as Api from '../api';
 import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
-import { COOKIE_SESSION_NAME, THUMBNAIL_SIZES } from '../config/constants';
+import { THUMBNAIL_SIZES } from '../config/constants';
 import {
   CURRENT_MEMBER_KEY,
   MUTATION_KEYS,
@@ -29,7 +28,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       Api.deleteMember(payload, queryConfig).then(() =>
         Api.signOut(queryConfig),
       ),
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       notifier?.({
         type: deleteMemberRoutine.SUCCESS,
         payload: { message: SUCCESS_MESSAGES.DELETE_MEMBER },
@@ -37,8 +36,11 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
       queryClient.resetQueries();
 
-      // remove cookies from browser when the logout is confirmed
-      Cookies.remove(COOKIE_SESSION_NAME);
+      // remove cookies from browser when logout succeeds
+      if (queryConfig.DOMAIN) {
+        removeSession(id, queryConfig.DOMAIN);
+        setCurrentSession(null, queryConfig.DOMAIN);
+      }
 
       // Update when the server confirmed the logout, instead optimistically updating the member
       // This prevents logout loop (redirect to logout -> still cookie -> logs back in)

--- a/src/mutations/member.ts
+++ b/src/mutations/member.ts
@@ -1,7 +1,17 @@
-import { QueryClient } from 'react-query';
-import { SUCCESS_MESSAGES } from '@graasp/translations';
 import Cookies from 'js-cookie';
+import { QueryClient } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import * as Api from '../api';
+import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
+import { COOKIE_SESSION_NAME, THUMBNAIL_SIZES } from '../config/constants';
+import {
+  CURRENT_MEMBER_KEY,
+  MUTATION_KEYS,
+  buildAvatarKey,
+} from '../config/keys';
 import {
   addFavoriteItemRoutine,
   deleteFavoriteItemRoutine,
@@ -9,15 +19,7 @@ import {
   editMemberRoutine,
   uploadAvatarRoutine,
 } from '../routines';
-import {
-  buildAvatarKey,
-  CURRENT_MEMBER_KEY,
-  MUTATION_KEYS,
-} from '../config/keys';
 import { MemberRecord, QueryClientConfig, UUID } from '../types';
-import { COOKIE_SESSION_NAME, THUMBNAIL_SIZES } from '../config/constants';
-import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
-import { convertJs } from '../utils/util';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const { notifier } = queryConfig;

--- a/src/mutations/membership.test.ts
+++ b/src/mutations/membership.test.ts
@@ -1,18 +1,21 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import nock from 'nock';
-import { List } from 'immutable';
-import { act } from 'react-test-renderer';
 import { StatusCodes } from 'http-status-codes';
+import { List } from 'immutable';
 import Cookies from 'js-cookie';
+import nock from 'nock';
+import { act } from 'react-test-renderer';
+
+import { HttpMethod, PermissionLevel } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
+
 import {
-  buildMockInvitations,
   ITEMS,
   ITEM_MEMBERSHIPS_RESPONSE,
   MEMBERS_RESPONSE,
   MEMBER_RESPONSE,
   OK_RESPONSE,
   UNAUTHORIZED_RESPONSE,
+  buildMockInvitations,
 } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
@@ -23,20 +26,19 @@ import {
   buildPostItemMembershipRoute,
   buildPostManyItemMembershipsRoute,
 } from '../api/routes';
-import { REQUEST_METHODS } from '../api/utils';
 import {
+  MUTATION_KEYS,
+  OWN_ITEMS_KEY,
   buildItemInvitationsKey,
   buildItemKey,
   buildItemMembershipsKey,
-  MUTATION_KEYS,
-  OWN_ITEMS_KEY,
 } from '../config/keys';
 import {
   deleteItemMembershipRoutine,
   editItemMembershipRoutine,
   shareItemRoutine,
 } from '../routines';
-import { MembershipRecord, PERMISSION_LEVELS } from '../types';
+import { ItemMembershipRecord } from '../types';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, useMutation } = setUpTest({
@@ -57,7 +59,7 @@ describe('Membership Mutations', () => {
   const memberships = ITEM_MEMBERSHIPS_RESPONSE;
   const membershipsKey = buildItemMembershipsKey(itemId);
   const membershipId = memberships.first()!.id;
-  const permission = PERMISSION_LEVELS.READ;
+  const permission = PermissionLevel.Read;
 
   describe(MUTATION_KEYS.POST_ITEM_MEMBERSHIP, () => {
     const mutation = () => useMutation(MUTATION_KEYS.POST_ITEM_MEMBERSHIP);
@@ -82,12 +84,12 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [MEMBERS_RESPONSE],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy([email])}`,
         },
         {
           response,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -125,13 +127,13 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [MEMBERS_RESPONSE],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy([email])}`,
         },
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route,
         },
       ];
@@ -163,7 +165,7 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           route,
         },
       ];
@@ -198,7 +200,7 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: UNAUTHORIZED_RESPONSE,
-          method: REQUEST_METHODS.PATCH,
+          method: HttpMethod.PATCH,
           statusCode: StatusCodes.UNAUTHORIZED,
           route,
         },
@@ -236,7 +238,7 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: {},
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -256,7 +258,7 @@ describe('Membership Mutations', () => {
         queryClient.getQueryState(membershipsKey)?.isInvalidated,
       ).toBeTruthy();
       expect(
-        queryClient.getQueryData<List<MembershipRecord>>(membershipsKey),
+        queryClient.getQueryData<List<ItemMembershipRecord>>(membershipsKey),
       ).toEqualImmutable(memberships.filter(({ id }) => id !== membershipId));
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: deleteItemMembershipRoutine.SUCCESS,
@@ -271,7 +273,7 @@ describe('Membership Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.DELETE,
+          method: HttpMethod.DELETE,
           route,
         },
       ];
@@ -291,7 +293,7 @@ describe('Membership Mutations', () => {
         queryClient.getQueryState(membershipsKey)?.isInvalidated,
       ).toBeTruthy();
       expect(
-        queryClient.getQueryData<List<MembershipRecord>>(membershipsKey),
+        queryClient.getQueryData<List<ItemMembershipRecord>>(membershipsKey),
       ).toEqualImmutable(memberships);
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -325,17 +327,17 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [MEMBERS_RESPONSE],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy(emails)}`,
         },
         {
           response: ITEM_MEMBERSHIPS_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostManyItemMembershipsRoute(itemId)}`,
         },
         {
           response: initialInvitations,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostInvitationsRoute(itemId)}`,
         },
       ];
@@ -384,17 +386,17 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [[{ email: emails[0], id: emails[0] }]],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy(emails)}`,
         },
         {
           response: [...ITEM_MEMBERSHIPS_RESPONSE, UNAUTHORIZED_RESPONSE],
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostManyItemMembershipsRoute(itemId)}`,
         },
         {
           response: [...initialInvitations, UNAUTHORIZED_RESPONSE],
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostInvitationsRoute(itemId)}`,
         },
       ];
@@ -448,7 +450,7 @@ describe('Membership Mutations', () => {
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy(emails)}`,
         },
       ];
@@ -497,18 +499,18 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [[{ email: emails[0], id: emails[0] }]],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy(emails)}`,
         },
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostManyItemMembershipsRoute(itemId)}`,
         },
         {
           response: initialInvitations,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostInvitationsRoute(itemId)}`,
         },
       ];
@@ -559,18 +561,18 @@ describe('Membership Mutations', () => {
       const endpoints = [
         {
           response: [[{ email: emails[0], id: emails[0] }]],
-          method: REQUEST_METHODS.GET,
+          method: HttpMethod.GET,
           route: `/${buildGetMembersBy(emails)}`,
         },
         {
           response: ITEM_MEMBERSHIPS_RESPONSE,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostManyItemMembershipsRoute(itemId)}`,
         },
         {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
-          method: REQUEST_METHODS.POST,
+          method: HttpMethod.POST,
           route: `/${buildPostInvitationsRoute(itemId)}`,
         },
       ];

--- a/src/mutations/mentions.test.ts
+++ b/src/mutations/mentions.test.ts
@@ -1,32 +1,33 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { act } from '@testing-library/react-hooks';
-import nock from 'nock';
-import Cookies from 'js-cookie';
 import { StatusCodes } from 'http-status-codes';
+import Cookies from 'js-cookie';
+import nock from 'nock';
+
+import { HttpMethod, MentionStatus } from '@graasp/sdk';
+
 import {
-  buildClearMentionsRoute,
-  buildDeleteMentionRoute,
-  buildPatchMentionRoute,
-  GET_CURRENT_MEMBER_ROUTE,
-} from '../api/routes';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
-import {
-  buildChatMention,
-  buildMemberMentions,
-  buildMentionResponse,
   MEMBER_RESPONSE,
   MENTION_IDS,
   OK_RESPONSE,
   UNAUTHORIZED_RESPONSE,
+  buildChatMention,
+  buildMemberMentions,
+  buildMentionResponse,
 } from '../../test/constants';
-import { buildMentionKey, MUTATION_KEYS } from '../config/keys';
-import { REQUEST_METHODS } from '../api/utils';
+import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import {
+  GET_CURRENT_MEMBER_ROUTE,
+  buildClearMentionsRoute,
+  buildDeleteMentionRoute,
+  buildPatchMentionRoute,
+} from '../api/routes';
+import { MUTATION_KEYS, buildMentionKey } from '../config/keys';
 import {
   clearMentionsRoutine,
   deleteMentionRoutine,
   patchMentionRoutine,
 } from '../routines';
-import { MentionStatus } from '@graasp/sdk';
 
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
 
@@ -63,10 +64,10 @@ describe('Mention Mutations', () => {
             route,
             response: buildMentionResponse(
               MENTIONS[0],
-              REQUEST_METHODS.PATCH,
+              HttpMethod.PATCH,
               MentionStatus.READ,
             ),
-            method: REQUEST_METHODS.PATCH,
+            method: HttpMethod.PATCH,
           },
         ];
         // set random data in cache
@@ -100,7 +101,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.PATCH,
+            method: HttpMethod.PATCH,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -145,7 +146,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: OK_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
           },
         ];
         // set random data in cache
@@ -178,7 +179,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -222,7 +223,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: OK_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
           },
         ];
         // set random data in cache
@@ -248,7 +249,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: UNAUTHORIZED_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
             statusCode: StatusCodes.UNAUTHORIZED,
           },
         ];
@@ -299,7 +300,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: OK_RESPONSE,
-            method: REQUEST_METHODS.PATCH,
+            method: HttpMethod.PATCH,
           },
         ];
         // set random data in cache
@@ -337,7 +338,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: OK_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
           },
         ];
         // set random data in cache
@@ -374,7 +375,7 @@ describe('Mention Mutations', () => {
           {
             route,
             response: OK_RESPONSE,
-            method: REQUEST_METHODS.DELETE,
+            method: HttpMethod.DELETE,
           },
         ];
         // set random data in cache

--- a/src/mutations/mentions.ts
+++ b/src/mutations/mentions.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from 'react-query';
+
 import * as Api from '../api';
-import { buildMentionKey, MUTATION_KEYS } from '../config/keys';
+import { MUTATION_KEYS, buildMentionKey } from '../config/keys';
 import {
   clearMentionsRoutine,
   deleteMentionRoutine,

--- a/src/mutations/plan.ts
+++ b/src/mutations/plan.ts
@@ -1,4 +1,6 @@
 import { QueryClient } from 'react-query';
+
+import * as Api from '../api';
 import {
   CURRENT_CUSTOMER_KEY,
   MUTATION_KEYS,
@@ -9,7 +11,6 @@ import {
   createSetupIntentRoutine,
   setDefaultCardRoutine,
 } from '../routines';
-import * as Api from '../api';
 import { QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {

--- a/src/mutations/thumbnails.ts
+++ b/src/mutations/thumbnails.ts
@@ -1,9 +1,11 @@
 import { QueryClient } from 'react-query';
+
 import { SUCCESS_MESSAGES } from '@graasp/translations';
-import { buildItemKey, MUTATION_KEYS } from '../config/keys';
-import { QueryClientConfig } from '../types';
+
 import { throwIfArrayContainsErrorOrReturn } from '../api/axios';
+import { MUTATION_KEYS, buildItemKey } from '../config/keys';
 import { uploadItemThumbnailRoutine } from '../routines';
+import { QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const { notifier } = queryConfig;
@@ -11,7 +13,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   /**
    * @param {UUID} id membership id to edit
    * @param {UUID} itemId corresponding item id
-   * @param {PERMISSION_LEVELS} permission permission level to apply
+   * @param {PermissionLevel} permission permission level to apply
    */
   queryClient.setMutationDefaults(MUTATION_KEYS.UPLOAD_ITEM_THUMBNAIL, {
     mutationFn: async ({ error, data }) => {

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,13 +1,14 @@
 import { AxiosError } from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import {
+  Hydrate,
   QueryClient,
   QueryClientProvider,
-  useMutation,
-  Hydrate,
   dehydrate,
+  useMutation,
 } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+
 import {
   CACHE_TIME_MILLISECONDS,
   STALE_TIME_MILLISECONDS,
@@ -16,8 +17,8 @@ import configureHooks from './hooks';
 import configureMutations from './mutations';
 import type { QueryClientConfig } from './types';
 import { getHostname } from './utils/util';
-import { configureWebsocketClient } from './ws';
 import { isDataEqual } from './utils/util';
+import { configureWebsocketClient } from './ws';
 
 /* istanbul ignore next */
 // Query client retry function decides when and how many times a request should be retried

--- a/src/routines/member.ts
+++ b/src/routines/member.ts
@@ -1,5 +1,7 @@
 import createRoutine from './utils';
 
+export const getMembersRoutine = createRoutine('GET_MEMBERS');
+
 export const editMemberRoutine = createRoutine('EDIT_MEMBER');
 export const deleteMemberRoutine = createRoutine('DELETE_MEMBER');
 export const uploadAvatarRoutine = createRoutine('UPLOAD_AVATAR');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,15 @@
-import { RecordOf, List } from 'immutable';
-import { MentionStatus } from '@graasp/sdk';
+import { List, RecordOf } from 'immutable';
+
+import {
+  Item,
+  ItemMembership,
+  ItemSettings,
+  Member,
+  MemberExtra,
+  MentionStatus,
+  PermissionLevel,
+  UnknownExtra,
+} from '@graasp/sdk';
 
 export type Notifier = (e: unknown) => void;
 
@@ -31,58 +41,19 @@ export type QueryClientConfig = {
   };
 };
 
-// Graasp Core Types
-// todo: use graasp-types
-
 export type UUID = string;
-
-export type ItemSettings = {
-  hasThumbnail?: boolean;
-};
 
 export type ItemSettingsRecord = RecordOf<ItemSettings>;
 
-export type Item = {
-  id: UUID;
-  name: string;
-  path: string;
-  type: string;
-  description: string;
-  extra: unknown;
-  settings?: ItemSettingsRecord;
-};
+export type ItemExtraRecord = RecordOf<UnknownExtra>;
 
-export type ItemRecord = RecordOf<Item>;
-
-export type MemberExtra = {
-  hasAvatar?: boolean;
-};
+export type ItemRecord = RecordOf<Item<ItemExtraRecord, ItemSettingsRecord>>;
 
 export type MemberExtraRecord = RecordOf<MemberExtra>;
 
-export type Member = {
-  id: UUID;
-  name: string;
-  email: string;
-  extra: MemberExtraRecord;
-};
+export type MemberRecord = RecordOf<Member<MemberExtraRecord>>;
 
-export type MemberRecord = RecordOf<Member>;
-
-export type Membership = {
-  id: UUID;
-  memberId: string;
-  itemId: string;
-  permission: string;
-};
-
-export type MembershipRecord = RecordOf<Membership>;
-
-export type ExtendedItem = Item & {
-  parentId: UUID;
-};
-
-export type Permission = string;
+export type ItemMembershipRecord = RecordOf<ItemMembership>;
 
 export type ItemTag = {
   id: UUID;
@@ -115,16 +86,6 @@ export type ItemCategory = {
 
 export type ItemCategoryRecord = RecordOf<ItemCategory>;
 
-export class UndefinedArgument extends Error {
-  constructor() {
-    super();
-    this.message = 'UnexpectedInput';
-    this.name = 'UnexpectedInput';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.stack = (<any>new Error()).stack;
-  }
-}
-
 export enum ITEM_LOGIN_SCHEMAS {
   USERNAME = 'username',
   USERNAME_AND_PASSWORD = 'username+password',
@@ -135,17 +96,6 @@ export type ItemLogin = {
 };
 
 export type ItemLoginRecord = RecordOf<ItemLogin>;
-
-// todo: use types from graasp types
-export enum ITEM_TYPES {
-  FOLDER = 'folder',
-}
-
-export enum PERMISSION_LEVELS {
-  READ = 'read',
-  WRITE = 'write',
-  ADMIN = 'admin',
-}
 
 export type ChatMention = {
   id: string;
@@ -204,15 +154,6 @@ export type ItemChat = {
 
 export type ItemChatRecord = RecordOf<ItemChat>;
 
-// todo: get from graasp types
-export type GraaspError = {
-  name: string;
-  code: string;
-  statusCode?: number;
-  message: string;
-  data?: unknown;
-};
-
 // a combined record from item-validation, item-validation-review, item-validation-process
 export type FullValidationRecord = {
   id: string;
@@ -257,7 +198,6 @@ export type StatusRecord = RecordOf<Status>;
 
 export interface Action {
   id: string;
-  name?: string;
   itemId: UUID;
   memberId: UUID;
 }
@@ -265,7 +205,7 @@ export interface Action {
 export type ActionRecord = RecordOf<Action>;
 
 export interface ActionData {
-  actions: List<Action>;
+  actions: List<ActionRecord>;
 }
 
 export type ActionDataRecord = RecordOf<ActionData>;
@@ -273,7 +213,7 @@ export type ActionDataRecord = RecordOf<ActionData>;
 export type Invitation = {
   id: UUID;
   email: string;
-  permission?: string;
+  permission?: PermissionLevel;
   name?: string;
   creator: UUID;
   itemPath: string;

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -1,7 +1,7 @@
 /** Utils functions
  * todo: use utils from a dedicated repo */
-
 import CryptoJS from 'crypto-js';
+
 import type { UUID } from '../types';
 
 // eslint-disable-next-line no-useless-escape

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,4 +1,4 @@
-import { List, Record, RecordOf, Seq, is } from 'immutable';
+import { List, RecordOf, is } from 'immutable';
 
 export const isObject = (value: unknown) =>
   typeof value === 'object' && !Array.isArray(value) && value !== null;
@@ -16,20 +16,6 @@ export const getHostname = () => {
   return window?.location?.hostname;
 };
 
-export function convertJs<T extends object>(data: T) {
-  if (typeof data !== 'object' || data === null) {
-    return data;
-  }
-
-  if (Array.isArray(data) || data instanceof Map) {
-    return Seq<any>(data).map(convertJs).toList();
-  }
-
-  const Factory = Record(data);
-
-  return new Factory(Seq<any>(data).map(convertJs));
-}
-
 export const isDataEqual = (
   oldData:
     | RecordOf<any>
@@ -37,6 +23,4 @@ export const isDataEqual = (
     | List<List<RecordOf<any>>>
     | undefined,
   newData: RecordOf<any> | List<RecordOf<any>> | List<List<RecordOf<any>>>,
-): boolean => {
-  return is(oldData, newData);
-};
+): boolean => is(oldData, newData);

--- a/src/ws/hooks/chat.test.ts
+++ b/src/ws/hooks/chat.test.ts
@@ -1,13 +1,13 @@
+import { ITEMS, ITEM_CHAT, MESSAGE_IDS } from '../../../test/constants';
 import {
   getHandlerByChannel,
   mockWsHook,
   setUpWsTest,
 } from '../../../test/wsUtils';
-import { ITEMS, ITEM_CHAT, MESSAGE_IDS } from '../../../test/constants';
 import { buildItemChatKey } from '../../config/keys';
-import { configureWsChatHooks } from './chat';
-import { KINDS, OPS, TOPICS } from '../constants';
 import { ItemChatRecord } from '../../types';
+import { KINDS, OPS, TOPICS } from '../constants';
+import { configureWsChatHooks } from './chat';
 
 const { hooks, wrapper, queryClient, handlers } = setUpWsTest({
   configureWsHooks: configureWsChatHooks,

--- a/src/ws/hooks/chat.ts
+++ b/src/ws/hooks/chat.ts
@@ -1,9 +1,11 @@
 import { List, RecordOf } from 'immutable';
 import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import { buildItemChatKey } from '../../config/keys';
-import { ItemChat, ChatMessage, ChatMessageRecord, UUID } from '../../types';
-import { convertJs } from '../../utils/util';
+import { ChatMessage, ChatMessageRecord, ItemChat, UUID } from '../../types';
 import { KINDS, OPS, TOPICS } from '../constants';
 import { Channel, WebsocketClient } from '../ws-client';
 

--- a/src/ws/hooks/item.test.ts
+++ b/src/ws/hooks/item.test.ts
@@ -1,20 +1,23 @@
-import Cookies from 'js-cookie';
 import { List } from 'immutable';
+import Cookies from 'js-cookie';
+
+import { Item } from '@graasp/sdk';
+
+import { ITEMS } from '../../../test/constants';
 import {
   getHandlerByChannel,
   mockWsHook,
   setUpWsTest,
 } from '../../../test/wsUtils';
-import { ITEMS } from '../../../test/constants';
 import {
-  buildItemChildrenKey,
-  buildItemKey,
   OWN_ITEMS_KEY,
   SHARED_ITEMS_KEY,
+  buildItemChildrenKey,
+  buildItemKey,
 } from '../../config/keys';
-import { Item, ItemRecord } from '../../types';
-import { configureWsItemHooks } from './item';
+import { ItemRecord } from '../../types';
 import { KINDS, OPS, TOPICS } from '../constants';
+import { configureWsItemHooks } from './item';
 
 const { hooks, wrapper, queryClient, handlers } = setUpWsTest({
   configureWsHooks: configureWsItemHooks,

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -2,19 +2,20 @@
  * Graasp websocket client
  * React effect hooks to subscribe to real-time updates and mutate query client
  */
-
 import { List } from 'immutable';
 import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
 import {
-  buildItemChildrenKey,
-  buildItemKey,
   OWN_ITEMS_KEY,
   SHARED_ITEMS_KEY,
+  buildItemChildrenKey,
+  buildItemKey,
 } from '../../config/keys';
 import { ItemRecord, UUID } from '../../types';
-import { convertJs } from '../../utils/util';
-import { TOPICS, OPS, KINDS } from '../constants';
+import { KINDS, OPS, TOPICS } from '../constants';
 import { Channel, WebsocketClient } from '../ws-client';
 
 // TODO: use graasp-types?

--- a/src/ws/hooks/mentions.test.ts
+++ b/src/ws/hooks/mentions.test.ts
@@ -1,19 +1,21 @@
 import { List } from 'immutable';
+
+import { MentionStatus } from '@graasp/sdk';
+
+import {
+  MEMBER_RESPONSE,
+  buildChatMention,
+  buildMemberMentions,
+} from '../../../test/constants';
 import {
   getHandlerByChannel,
   mockWsHook,
   setUpWsTest,
 } from '../../../test/wsUtils';
-import {
-  buildMemberMentions,
-  buildChatMention,
-  MEMBER_RESPONSE,
-} from '../../../test/constants';
 import { buildItemChatKey, buildMentionKey } from '../../config/keys';
-import { OPS, TOPICS } from '../constants';
 import { MemberMentionsRecord } from '../../types';
+import { OPS, TOPICS } from '../constants';
 import { configureWsChatMentionsHooks } from './mentions';
-import { MentionStatus } from '@graasp/sdk';
 
 const { hooks, wrapper, queryClient, handlers } = setUpWsTest({
   configureWsHooks: configureWsChatMentionsHooks,

--- a/src/ws/hooks/mentions.ts
+++ b/src/ws/hooks/mentions.ts
@@ -1,6 +1,10 @@
 import { List, Record } from 'immutable';
 import { useEffect } from 'react';
 import { QueryClient } from 'react-query';
+
+import { convertJs } from '@graasp/sdk';
+
+import { buildMentionKey } from '../../config/keys';
 import {
   ChatMention,
   ChatMentionRecord,
@@ -9,8 +13,6 @@ import {
 } from '../../types';
 import { OPS, TOPICS } from '../constants';
 import { Channel, WebsocketClient } from '../ws-client';
-import { buildMentionKey } from '../../config/keys';
-import { convertJs } from '../../utils/util';
 
 // todo: use graasp-types?
 interface MentionEvent {

--- a/src/ws/protocol.ts
+++ b/src/ws/protocol.ts
@@ -1,7 +1,6 @@
 /**
  * TODO: use types from graasp-websockets
  */
-
 import {
   CLIENT_ACTION_DISCONNECT,
   CLIENT_ACTION_SUBSCRIBE,

--- a/src/ws/ws-client.ts
+++ b/src/ws/ws-client.ts
@@ -3,7 +3,6 @@
  * Provides front-end integration for real-time updates using WebSocket
  * Implements the client protocol from https://github.com/graasp/graasp-websockets
  */
-
 import { QueryClientConfig } from '../types';
 import {
   CLIENT_ACTION_SUBSCRIBE,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,5 +1,20 @@
 import { StatusCodes } from 'http-status-codes';
-import { List, Record, RecordOf } from 'immutable';
+import { List, Record } from 'immutable';
+import { v4 } from 'uuid';
+
+import {
+  HttpMethod,
+  Item,
+  ItemMembership,
+  ItemSettings,
+  ItemType,
+  Member,
+  MemberExtra,
+  MemberType,
+  MentionStatus,
+  PermissionLevel,
+  UnknownExtra,
+} from '@graasp/sdk';
 
 import {
   Action,
@@ -13,53 +28,46 @@ import {
   CategoryType,
   CategoryTypeRecord,
   ChatMention,
+  ChatMentionRecord,
   ChatMessage,
   ChatMessageRecord,
   Flag,
   FlagRecord,
   FullValidationRecord,
   FullValidationRecordRecord,
+  ITEM_LOGIN_SCHEMAS,
   Invitation,
   InvitationRecord,
-  Item,
   ItemCategory,
   ItemCategoryRecord,
+  ItemExtraRecord,
   ItemLike,
   ItemLikeRecord,
   ItemLogin,
   ItemLoginRecord,
+  ItemMembershipRecord,
   ItemRecord,
+  ItemSettingsRecord,
   ItemTag,
   ItemTagRecord,
   ItemValidationAndReview,
   ItemValidationAndReviewRecord,
   ItemValidationGroup,
   ItemValidationGroupRecord,
-  ITEM_LOGIN_SCHEMAS,
-  ITEM_TYPES,
-  Member,
-  MemberExtra,
   MemberExtraRecord,
+  MemberMentions,
+  MemberMentionsRecord,
   MemberRecord,
-  Membership,
-  MembershipRecord,
   MessageItemChat,
   MessageItemChatList,
   MessageItemChatListRecord,
   MessageItemChatRecord,
-  PERMISSION_LEVELS,
   Status,
   StatusRecord,
   Tag,
   TagRecord,
   UUID,
-  ChatMentionRecord,
-  MemberMentions,
-  MemberMentionsRecord,
 } from '../src/types';
-import { REQUEST_METHODS } from '../src/api/utils';
-import { v4 } from 'uuid';
-import { MentionStatus } from '@graasp/sdk';
 
 export const WS_HOST = 'ws://localhost:3000';
 export const API_HOST = 'http://localhost:3000';
@@ -69,74 +77,61 @@ export const UNAUTHORIZED_RESPONSE = {
   code: 'ERRCODE',
   message: 'unauthorized error message',
   statusCode: StatusCodes.UNAUTHORIZED,
+  origin: 'plugin',
 };
 
-const defaultItemExtraValues: any = {};
-const createItemExtra: Record.Factory<any> = Record(defaultItemExtraValues);
-const extra: RecordOf<any> = createItemExtra({});
+const createItemExtra: Record.Factory<UnknownExtra> = Record({});
+const createItemSettings: Record.Factory<ItemSettings> = Record({});
 
-const defaultItemValues: Item = {
+const createMockItem: Record.Factory<
+  Item<ItemExtraRecord, ItemSettingsRecord>
+> = Record({
   id: '42',
   name: 'item1',
   path: '42',
-  type: ITEM_TYPES.FOLDER,
+  type: ItemType.FOLDER as ItemType,
   description: '',
-  extra: extra,
-};
-const createMockItem: Record.Factory<Item> = Record(defaultItemValues);
+  extra: createItemExtra({}),
+  creator: 'creator',
+  updatedAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  settings: createItemSettings({}),
+});
 
 const ITEM_1: ItemRecord = createMockItem({
   id: '42',
   name: 'item1',
   path: '42',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 const ITEM_2: ItemRecord = createMockItem({
   id: '5243',
   name: 'item2',
   path: '5243',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 const ITEM_3: ItemRecord = createMockItem({
   id: '5896',
   name: 'item3',
   path: '5896',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 const ITEM_4: ItemRecord = createMockItem({
   id: 'dddd',
   name: 'item4',
   path: '5896.dddd',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 const ITEM_5: ItemRecord = createMockItem({
   id: 'eeee',
   name: 'item5',
   path: '5896.eeee',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 const ITEM_6: ItemRecord = createMockItem({
   id: 'gggg',
   name: 'item5',
   path: '5896.gggg',
-  type: ITEM_TYPES.FOLDER,
-  description: '',
-  extra: extra,
 });
 
 export const ITEMS: List<ItemRecord> = List([
@@ -154,15 +149,16 @@ const defaultMemberExtraValues: MemberExtra = {};
 const createMemberExtra: Record.Factory<MemberExtra> = Record(
   defaultMemberExtraValues,
 );
-const extraMember: MemberExtraRecord = createMemberExtra({});
 
-const defaultMemberValues: Member = {
+const createMockMember: Record.Factory<Member<MemberExtraRecord>> = Record({
   id: '42',
   name: 'username',
   email: 'username@graasp.org',
-  extra: extraMember,
-};
-const createMockMember: Record.Factory<Member> = Record(defaultMemberValues);
+  type: MemberType.Individual as MemberType,
+  extra: createMemberExtra({}),
+  updatedAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+});
 
 export const MEMBER_RESPONSE: MemberRecord = createMockMember();
 
@@ -175,7 +171,7 @@ export const GET_RECYCLED_ITEMS_FIXTURES = {
       id: `${recycleBinItemId}.42`,
       name: 'item1',
       path: '42',
-      type: ITEM_TYPES.FOLDER,
+      type: ItemType.FOLDER,
       description: '',
       extra: {},
     },
@@ -183,7 +179,7 @@ export const GET_RECYCLED_ITEMS_FIXTURES = {
       id: `${recycleBinItemId}.5243`,
       name: 'item2',
       path: '5243',
-      type: ITEM_TYPES.FOLDER,
+      type: ItemType.FOLDER,
       description: '',
       extra: {},
     },
@@ -191,7 +187,7 @@ export const GET_RECYCLED_ITEMS_FIXTURES = {
       id: `${recycleBinItemId}.5896`,
       name: 'item3',
       path: '5896',
-      type: ITEM_TYPES.FOLDER,
+      type: ItemType.FOLDER,
       description: '',
       extra: {},
     },
@@ -199,7 +195,7 @@ export const GET_RECYCLED_ITEMS_FIXTURES = {
       id: `${recycleBinItemId}.dddd`,
       name: 'item4',
       path: '5896.dddd',
-      type: ITEM_TYPES.FOLDER,
+      type: ItemType.FOLDER,
       description: '',
       extra: {},
     },
@@ -218,7 +214,6 @@ const MEMBER_RESPONSE_2: MemberRecord = createMockMember({
   id: '421',
   name: 'username1',
   email: 'username1@graasp.org',
-  extra: extraMember,
 });
 
 export const MEMBERS_RESPONSE: List<MemberRecord> = List([
@@ -228,31 +223,32 @@ export const MEMBERS_RESPONSE: List<MemberRecord> = List([
 
 export const OK_RESPONSE = {};
 
-const defaultMembershipValues: Membership = {
+const createMockMembership: Record.Factory<ItemMembership> = Record({
   id: 'membership-id',
   memberId: 'member-id',
-  itemId: ITEMS.toArray()[0].id,
-  permission: PERMISSION_LEVELS.READ,
-};
-const createMockMembership: Record.Factory<Membership> = Record(
-  defaultMembershipValues,
-);
-
-const MEMBERSHIP_1: MembershipRecord = createMockMembership({
-  id: 'membership-id',
-  memberId: 'member-id',
-  itemId: ITEMS.toArray()[0].id,
-  permission: PERMISSION_LEVELS.READ,
+  itemPath: ITEMS.first()!.path,
+  // clearly type enum for immutable record
+  permission: PermissionLevel.Read as PermissionLevel,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  creator: 'creator-id',
 });
 
-const MEMBERSHIP_2: MembershipRecord = createMockMembership({
+const MEMBERSHIP_1: ItemMembershipRecord = createMockMembership({
+  id: 'membership-id',
+  memberId: 'member-id',
+  itemPath: ITEMS.first()!.path,
+  permission: PermissionLevel.Read,
+});
+
+const MEMBERSHIP_2: ItemMembershipRecord = createMockMembership({
   id: 'membership-id1',
   memberId: 'member-id1',
-  itemId: ITEMS.toArray()[0].id,
-  permission: PERMISSION_LEVELS.ADMIN,
+  itemPath: ITEMS.first()!.path,
+  permission: PermissionLevel.Admin,
 });
 
-export const ITEM_MEMBERSHIPS_RESPONSE: List<MembershipRecord> = List([
+export const ITEM_MEMBERSHIPS_RESPONSE: List<ItemMembershipRecord> = List([
   MEMBERSHIP_1,
   MEMBERSHIP_2,
 ]);
@@ -282,16 +278,16 @@ export const AVATAR_BLOB_RESPONSE = BlobMock;
 
 export const buildMentionResponse = (
   mention: ChatMention,
-  method: REQUEST_METHODS,
+  method: HttpMethod,
   status?: MentionStatus,
 ): ChatMention => {
   switch (method) {
-    case REQUEST_METHODS.PATCH:
+    case HttpMethod.PATCH:
       return {
         ...mention,
         status: status || mention.status,
       };
-    case REQUEST_METHODS.DELETE:
+    case HttpMethod.DELETE:
       return mention;
     default:
       return mention;
@@ -567,28 +563,23 @@ export enum Ranges {
   Author = 'author',
 }
 
-const defaultItemLikesValues: ItemLike = {
+const createMockItemLike: Record.Factory<ItemLike> = Record({
   id: 'id1',
   itemId: 'item-id',
   memberId: 'member-id',
-  createdAt: 'timestamp',
-};
-const createMockItemLike: Record.Factory<ItemLike> = Record(
-  defaultItemLikesValues,
-);
+  createdAt: new Date().toISOString(),
+});
 
 const ITEM_LIKE_1: ItemLikeRecord = createMockItemLike({
   id: 'id1',
   itemId: 'item-id',
   memberId: 'member-id',
-  createdAt: 'timestamp',
 });
 
 const ITEM_LIKE_2: ItemLikeRecord = createMockItemLike({
   id: 'id2',
   itemId: 'item-id2',
   memberId: 'member-id',
-  createdAt: 'timestamp',
 });
 
 export const ITEM_LIKES: List<ItemLikeRecord> = List([
@@ -598,11 +589,10 @@ export const ITEM_LIKES: List<ItemLikeRecord> = List([
 
 export const LIKE_COUNT = 100;
 
-const defaultStatusValues: Status = {
+const createMockStatus: Record.Factory<Status> = Record({
   id: 'id',
   name: 'status-1',
-};
-const createMockStatus: Record.Factory<Status> = Record(defaultStatusValues);
+});
 
 const STATUS_1: StatusRecord = createMockStatus({
   id: 'id',
@@ -616,35 +606,30 @@ const STATUS_2: StatusRecord = createMockStatus({
 
 export const STATUS_LIST: List<StatusRecord> = List([STATUS_1, STATUS_2]);
 
-const defaultItemValidationStatusValues: ItemValidationAndReview = {
-  itemValidationId: 'iv-id-1',
-  reviewStatusId: 'accepted',
-  reviewReason: '',
-  createdAt: 'ts',
-};
 const createMockItemValidationSatus: Record.Factory<ItemValidationAndReview> =
-  Record(defaultItemValidationStatusValues);
+  Record({
+    itemValidationId: 'iv-id-1',
+    reviewStatusId: 'accepted',
+    reviewReason: '',
+    createdAt: new Date().toISOString(),
+  });
 
 export const ITEM_VALIDATION_STATUS: ItemValidationAndReviewRecord =
   createMockItemValidationSatus({
     itemValidationId: 'iv-id-1',
     reviewStatusId: 'accepted',
     reviewReason: '',
-    createdAt: 'ts',
   });
 
-const defaultFullValidationValues: FullValidationRecord = {
+const createMockFullValidation: Record.Factory<FullValidationRecord> = Record({
   id: 'id-1',
   itemId: 'item-id-1',
   reviewStatusId: 'status-id-1',
   validationStatusId: 'status-id-2',
   validationResult: '',
   process: 'process-1',
-  createdAt: 'ts',
-};
-const createMockFullValidation: Record.Factory<FullValidationRecord> = Record(
-  defaultFullValidationValues,
-);
+  createdAt: new Date().toISOString(),
+});
 
 const FULL_VALIDATION_RECORDS_1: FullValidationRecordRecord =
   createMockFullValidation({
@@ -654,7 +639,6 @@ const FULL_VALIDATION_RECORDS_1: FullValidationRecordRecord =
     validationStatusId: 'status-id-2',
     validationResult: '',
     process: 'process-1',
-    createdAt: 'ts',
   });
 
 const FULL_VALIDATION_RECORDS_2: FullValidationRecordRecord =
@@ -665,7 +649,6 @@ const FULL_VALIDATION_RECORDS_2: FullValidationRecordRecord =
     validationStatusId: 'status-id-2',
     validationResult: '',
     process: 'process-2',
-    createdAt: 'ts',
   });
 
 export const FULL_VALIDATION_RECORDS: List<FullValidationRecordRecord> = List([
@@ -673,18 +656,17 @@ export const FULL_VALIDATION_RECORDS: List<FullValidationRecordRecord> = List([
   FULL_VALIDATION_RECORDS_2,
 ]);
 
-const defaultItemValidationGroupValues: ItemValidationGroup = {
-  id: 'id-1',
-  itemId: 'item-id-1',
-  itemValidationId: 'iv-id',
-  processId: 'ivp-id-1',
-  statusId: 'success-id',
-  result: '',
-  updatedAt: 'ts',
-  createdAt: '',
-};
 const createMockItemValidationGroup: Record.Factory<ItemValidationGroup> =
-  Record(defaultItemValidationGroupValues);
+  Record({
+    id: 'id-1',
+    itemId: 'item-id-1',
+    itemValidationId: 'iv-id',
+    processId: 'ivp-id-1',
+    statusId: 'success-id',
+    result: '',
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+  });
 
 const ITEM_VALIDATION_GROUP_1: ItemValidationGroupRecord =
   createMockItemValidationGroup({
@@ -694,8 +676,6 @@ const ITEM_VALIDATION_GROUP_1: ItemValidationGroupRecord =
     processId: 'ivp-id-1',
     statusId: 'success-id',
     result: '',
-    updatedAt: 'ts',
-    createdAt: '',
   });
 
 const ITEM_VALIDATION_GROUP_2: ItemValidationGroupRecord =
@@ -706,8 +686,6 @@ const ITEM_VALIDATION_GROUP_2: ItemValidationGroupRecord =
     processId: 'ivp-id-2',
     statusId: 'success-id',
     result: '',
-    updatedAt: 'ts',
-    createdAt: '',
   });
 
 export const ITEM_VALIDATION_GROUPS: List<ItemValidationGroupRecord> = List([
@@ -715,12 +693,11 @@ export const ITEM_VALIDATION_GROUPS: List<ItemValidationGroupRecord> = List([
   ITEM_VALIDATION_GROUP_2,
 ]);
 
-const defaultActionValues: Action = {
+const createMockAction: Record.Factory<Action> = Record({
   id: 'action-id',
   itemId: 'item-id',
   memberId: 'member-id',
-};
-const createMockAction: Record.Factory<Action> = Record(defaultActionValues);
+});
 
 const ACTION_1: ActionRecord = createMockAction({
   id: 'action-id',
@@ -730,13 +707,9 @@ const ACTION_1: ActionRecord = createMockAction({
 
 export const ACTIONS_LIST: List<ActionRecord> = List([ACTION_1]);
 
-const defaultActionDataValues: ActionData = {
+const createMockActionData: Record.Factory<ActionData> = Record({
   actions: ACTIONS_LIST,
-};
-
-const createMockActionData: Record.Factory<ActionData> = Record(
-  defaultActionDataValues,
-);
+});
 
 export const ACTIONS_DATA: ActionDataRecord = createMockActionData({
   actions: ACTIONS_LIST,
@@ -767,16 +740,13 @@ export const buildInvitationRecord = ({
   email?: string;
   name?: string;
 }) => {
-  const defaultInvitationValues: Invitation = {
+  const createMockInvitation: Record.Factory<Invitation> = Record({
     id: 'id',
     name: name ?? 'member-name',
     email: email ?? 'email',
     creator: 'creator-id',
     itemPath,
-  };
-  const createMockInvitation: Record.Factory<Invitation> = Record(
-    defaultInvitationValues,
-  );
+  });
   const invitation: InvitationRecord = createMockInvitation();
   return invitation;
 };

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -89,6 +89,7 @@ const createMockItem: Record.Factory<
   id: '42',
   name: 'item1',
   path: '42',
+  // clearly type enum for immutable record to correctly infer
   type: ItemType.FOLDER as ItemType,
   description: '',
   extra: createItemExtra({}),
@@ -227,7 +228,7 @@ const createMockMembership: Record.Factory<ItemMembership> = Record({
   id: 'membership-id',
   memberId: 'member-id',
   itemPath: ITEMS.first()!.path,
-  // clearly type enum for immutable record
+  // clearly type enum for immutable record to correctly infer
   permission: PermissionLevel.Read as PermissionLevel,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,6 +1,6 @@
 // redefine global type to mock fetch
-import { WebSocket } from 'mock-socket';
 import axios from 'axios';
+import { WebSocket } from 'mock-socket';
 
 // adapter for test
 axios.defaults.adapter = require('axios/lib/adapters/http');

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
 import {
-  renderHook,
   RenderResult,
   WaitFor,
+  renderHook,
 } from '@testing-library/react-hooks';
-import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
-import { QueryObserverBaseResult, MutationObserverResult } from 'react-query';
+import nock from 'nock';
+import React from 'react';
+import { MutationObserverResult, QueryObserverBaseResult } from 'react-query';
+
+import { HttpMethod } from '@graasp/sdk';
+
 import configureHooks from '../src/hooks';
-import { Notifier, QueryClientConfig } from '../src/types';
-import { API_HOST, WS_HOST, DOMAIN } from './constants';
 import configureQueryClient from '../src/queryClient';
-import { REQUEST_METHODS } from '../src/api/utils';
+import { Notifier, QueryClientConfig } from '../src/types';
 import { isDataEqual } from '../src/utils/util';
+import { API_HOST, DOMAIN, WS_HOST } from './constants';
 
 type Args = { enableWebsocket?: boolean; notifier?: Notifier };
 
@@ -30,7 +32,7 @@ export const setUpTest = (args?: Args) => {
       retry: 0,
       cacheTime: 0,
       staleTime: 0,
-      isDataEqual: isDataEqual,
+      isDataEqual,
     },
     SHOW_NOTIFICATIONS: false,
     notifier,
@@ -55,7 +57,7 @@ export type Endpoint = {
   route: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: any;
-  method?: REQUEST_METHODS;
+  method?: HttpMethod;
   statusCode?: number;
   headers?: unknown;
 };
@@ -79,7 +81,7 @@ export const mockEndpoints = (endpoints: Endpoint[]) => {
   // mock endpoint with given response
   const server = nock(API_HOST);
   endpoints.forEach(({ route, method, statusCode, response, headers }) => {
-    server[(method || REQUEST_METHODS.GET).toLowerCase()](route).reply(
+    server[(method || HttpMethod.GET).toLowerCase()](route).reply(
       statusCode || StatusCodes.OK,
       response,
       headers,

--- a/test/wsUtils.tsx
+++ b/test/wsUtils.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { Notifier, QueryClientConfig } from '../src/types';
-import { API_HOST, WS_HOST, DOMAIN } from './constants';
+import React from 'react';
+
 import configureQueryClient from '../src/queryClient';
-import { Channel } from '../src/ws/ws-client';
+import { Notifier, QueryClientConfig } from '../src/types';
 import { isDataEqual } from '../src/utils/util';
+import { Channel } from '../src/ws/ws-client';
+import { API_HOST, DOMAIN, WS_HOST } from './constants';
 
 export type Handler = { channel: Channel; handler: (event: unknown) => void };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.18.8":
+  version: 7.18.13
+  resolution: "@babel/compat-data@npm:7.18.13"
+  checksum: 869a730dc3ec40d4d5141b832d50b16702a2ea7bf5b87dc2761e7dfaa8deeafa03b8809fc42ff713ac1d450748dcdb07e1eb21f4633e10b87fd47be0065573e6
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:7.13.10":
+  version: 7.13.10
+  resolution: "@babel/core@npm:7.13.10"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.9
+    "@babel/helper-compilation-targets": ^7.13.10
+    "@babel/helper-module-transforms": ^7.13.0
+    "@babel/helpers": ^7.13.10
+    "@babel/parser": ^7.13.10
+    "@babel/template": ^7.12.13
+    "@babel/traverse": ^7.13.0
+    "@babel/types": ^7.13.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    lodash: ^4.17.19
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 9b3362fd02e6a4f3ad642893312ec3d22713c4eeb2571c994d49c31f38d24893a6a18f4b49abb8d56b510e116278608eaddde2ca72ccb39ab29350efa5af39de
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:7.17.10":
   version: 7.17.10
   resolution: "@babel/core@npm:7.17.10"
@@ -104,6 +135,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:7.13.9":
+  version: 7.13.9
+  resolution: "@babel/generator@npm:7.13.9"
+  dependencies:
+    "@babel/types": ^7.13.0
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 1b0e9fa1b5ea6656f0abeeedc99ff7bffa455d7bf118f4d17a75d80c439206b4ba3e1071c104b486b7447689512969286cbde505e6169ab38cf437e13ca54225
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.13.0, @babel/generator@npm:^7.13.9, @babel/generator@npm:^7.18.13":
+  version: 7.18.13
+  resolution: "@babel/generator@npm:7.18.13"
+  dependencies:
+    "@babel/types": ^7.18.13
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: 27f5e7eb774e4d76ee75dc96e3e1bd26cc0ee7cea13a8f7342b716319c0a4d4e26fc49aa8f19316f7c99383da55eeb2a866c6e034e9deacad58a9de9ed6004fb
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.17.10, @babel/generator@npm:^7.18.6, @babel/generator@npm:^7.18.7, @babel/generator@npm:^7.7.2":
   version: 7.18.7
   resolution: "@babel/generator@npm:7.18.7"
@@ -145,6 +198,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: f09ddaddc83c241cb7a040025e2ba558daa1c950ce878604d91230aed8d8a90f10dfd5bb0b67bc5b3db8af1576a0d0dac1d65959a06a17259243dbb5730d0ed1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.13.10":
+  version: 7.18.9
+  resolution: "@babel/helper-compilation-targets@npm:7.18.9"
+  dependencies:
+    "@babel/compat-data": ^7.18.8
+    "@babel/helper-validator-option": ^7.18.6
+    browserslist: ^4.20.2
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2a9d71e124e098a9f45de4527ddd1982349d231827d341e00da9dfb967e260ecc7662c8b62abee4a010fb34d5f07a8d2155c974e0bc1928144cee5644910621d
   languageName: node
   linkType: hard
 
@@ -202,12 +269,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-environment-visitor@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-environment-visitor@npm:7.18.9"
+  checksum: b25101f6162ddca2d12da73942c08ad203d7668e06663df685634a8fde54a98bc015f6f62938e8554457a592a024108d45b8f3e651fd6dcdb877275b73cc4420
+  languageName: node
+  linkType: hard
+
 "@babel/helper-explode-assignable-expression@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-explode-assignable-expression@npm:7.18.6"
   dependencies:
     "@babel/types": ^7.18.6
   checksum: 225cfcc3376a8799023d15dc95000609e9d4e7547b29528c7f7111a0e05493ffb12c15d70d379a0bb32d42752f340233c4115bded6d299bc0c3ab7a12be3d30f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.12.13, @babel/helper-function-name@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-function-name@npm:7.18.9"
+  dependencies:
+    "@babel/template": ^7.18.6
+    "@babel/types": ^7.18.9
+  checksum: d04c44e0272f887c0c868651be7fc3c5690531bea10936f00d4cca3f6d5db65e76dfb49e8d553c42ae1fe1eba61ccce9f3d93ba2df50a66408c8d4c3cc61cf0c
   languageName: node
   linkType: hard
 
@@ -245,6 +329,22 @@ __metadata:
   dependencies:
     "@babel/types": ^7.18.6
   checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.13.0":
+  version: 7.18.9
+  resolution: "@babel/helper-module-transforms@npm:7.18.9"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-simple-access": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/helper-validator-identifier": ^7.18.6
+    "@babel/template": ^7.18.6
+    "@babel/traverse": ^7.18.9
+    "@babel/types": ^7.18.9
+  checksum: af08c60ea239ff3d40eda542fceaab69de17e713f131e80ead08c975ba7a47dd55d439cb48cfb14ae7ec96704a10c989ff5a5240e52a39101cb44a49467ce058
   languageName: node
   linkType: hard
 
@@ -325,7 +425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.18.6":
+"@babel/helper-split-export-declaration@npm:^7.12.13, @babel/helper-split-export-declaration@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
   dependencies:
@@ -334,7 +434,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.18.6":
+"@babel/helper-string-parser@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/helper-string-parser@npm:7.18.10"
+  checksum: d554a4393365b624916b5c00a4cc21c990c6617e7f3fe30be7d9731f107f12c33229a7a3db9d829bfa110d2eb9f04790745d421640e3bd245bb412dc0ea123c1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.12.11, @babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
@@ -360,6 +467,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.13.10":
+  version: 7.18.9
+  resolution: "@babel/helpers@npm:7.18.9"
+  dependencies:
+    "@babel/template": ^7.18.6
+    "@babel/traverse": ^7.18.9
+    "@babel/types": ^7.18.9
+  checksum: d0bd8255d36bfc65dc52ce75f7fea778c70287da2d64981db4c84fbdf9581409ecbd6433deff1c81da3a5acf26d7e4c364b3a4445efacf88f4f48e77c5b34d8d
+  languageName: node
+  linkType: hard
+
 "@babel/helpers@npm:^7.17.9, @babel/helpers@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helpers@npm:7.18.6"
@@ -382,12 +500,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:7.14.6":
+  version: 7.14.6
+  resolution: "@babel/parser@npm:7.14.6"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 104482e07971a78a3d68a0c329b1303981a272f55a510d39c93dac3c293f207ec863329046abc5d8bb86db58c49670cc607654793470a87ccd386544c2ccf298
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.17.10, @babel/parser@npm:^7.18.6, @babel/parser@npm:^7.18.8, @babel/parser@npm:^7.3.3":
   version: 7.18.8
   resolution: "@babel/parser@npm:7.18.8"
   bin:
     parser: ./bin/babel-parser.js
   checksum: b8426083f753a000bdb4929cb18c6ce5b68c23759245bf123515bf86cacb9f6e7ff61341a6e0d01a779a9a8a826c86062a0f4db424b88b5b51f67e121985d400
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.13.0, @babel/parser@npm:^7.13.10, @babel/parser@npm:^7.18.10, @babel/parser@npm:^7.18.13":
+  version: 7.18.13
+  resolution: "@babel/parser@npm:7.18.13"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 8b41c35607668495d67d9a7c5f61768aaab26acf887efdadc2781aed54046981480ef40aeda0b84d61aed02cf0c4ff4b028d5f83ab85e17e2ddff318f9243b8b
   languageName: node
   linkType: hard
 
@@ -1601,6 +1737,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.12.13":
+  version: 7.18.10
+  resolution: "@babel/template@npm:7.18.10"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/parser": ^7.18.10
+    "@babel/types": ^7.18.10
+  checksum: 93a6aa094af5f355a72bd55f67fa1828a046c70e46f01b1606e6118fa1802b6df535ca06be83cc5a5e834022be95c7b714f0a268b5f20af984465a71e28f1473
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.16.7, @babel/template@npm:^7.18.6, @babel/template@npm:^7.3.3":
   version: 7.18.6
   resolution: "@babel/template@npm:7.18.6"
@@ -1609,6 +1756,23 @@ __metadata:
     "@babel/parser": ^7.18.6
     "@babel/types": ^7.18.6
   checksum: cb02ed804b7b1938dbecef4e01562013b80681843dd391933315b3dd9880820def3b5b1bff6320d6e4c6a1d63d1d5799630d658ec6b0369c5505e7e4029c38fb
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/traverse@npm:7.13.0"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.0
+    "@babel/helper-function-name": ^7.12.13
+    "@babel/helper-split-export-declaration": ^7.12.13
+    "@babel/parser": ^7.13.0
+    "@babel/types": ^7.13.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+    lodash: ^4.17.19
+  checksum: 7d584b5541396b02f6973ba8ec8a067f2a6c2fd2e894c663dfae36e86e65a004a6865fbffbfc89ca040c894f9c12134bb971d31f09e7ec32c28e9b18bf737f2a
   languageName: node
   linkType: hard
 
@@ -1630,6 +1794,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.18.9":
+  version: 7.18.13
+  resolution: "@babel/traverse@npm:7.18.13"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.18.13
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.18.9
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.18.13
+    "@babel/types": ^7.18.13
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 1a2ef738fac4968feba6385787a3f8f7357d08e7739ecc5b37d8ff5668935253a03290f700f02a85ccfd369d5898625f0722d7733bff2ef91504f6cd8b836f19
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/types@npm:7.13.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.12.11
+    lodash: ^4.17.19
+    to-fast-properties: ^2.0.0
+  checksum: 3dbb08add345325a49e1deebefa8d3774a8ab055c4be675c339a389358f4b3443652ded4bfdb230b342c6af12593a6fd3fb95156564e7ec84081018815896821
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.6, @babel/types@npm:^7.17.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.7, @babel/types@npm:^7.18.8, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.18.8
   resolution: "@babel/types@npm:7.18.8"
@@ -1637,6 +1830,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.18.6
     to-fast-properties: ^2.0.0
   checksum: a485531faa9ff3b83ea94ba6502321dd66e39202c46d7765e4336cb4aff2ff69ebc77d97b17e21331a8eedde1f5490ce00e8a430c1041fc26854d636e6701919
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.13.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.13, @babel/types@npm:^7.18.9":
+  version: 7.18.13
+  resolution: "@babel/types@npm:7.18.13"
+  dependencies:
+    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-validator-identifier": ^7.18.6
+    to-fast-properties: ^2.0.0
+  checksum: abc3ad1f3b6864df0ea0e778bcdf7d2c5ee2293811192962d50e8a8c05c1aeec90a48275f53b2a45aad882ed8bef9477ae1f8e70ac1d44d039e14930d1388dcc
   languageName: node
   linkType: hard
 
@@ -2081,13 +2285,14 @@ __metadata:
     "@babel/preset-typescript": 7.16.7
     "@commitlint/cli": 16.2.4
     "@commitlint/config-conventional": 16.2.4
-    "@graasp/sdk": "github:graasp/graasp-sdk"
+    "@graasp/sdk": "github:graasp/graasp-sdk#42/limits"
     "@graasp/translations": "github:graasp/graasp-translations.git"
     "@graasp/utils": "github:graasp/graasp-utils.git"
     "@testing-library/jest-dom": 5.16.4
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": 14.1.1
+    "@trivago/prettier-plugin-sort-imports": 3.2.0
     "@types/crypto-js": 4.1.1
     "@types/jest": 28.1.0
     "@types/js-cookie": 3.0.2
@@ -2136,9 +2341,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graasp/sdk@github:graasp/graasp-sdk":
+"@graasp/sdk@github:graasp/graasp-sdk#42/limits":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=5170aab6390aa6deb16b9be559a359bdec050cc9"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=c33a85f67736d0362ee2cbabb9250fab5e1980bb"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
@@ -2149,7 +2354,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: 4548423660f7c7d57f07ae1fa3d243e80d516f03bddd04c23df707aabe9302b671f22e17f318c48414960921a3fd9ee5144e0f0da057d070879923f1a0389edf
+  checksum: 8da44f403d13ff56b73897deeb729ab527152d57b65dedfbe9c2300afff509acb50fb3f097e27f1cfaca138a97aa28aeaf4931e108cf0288b4daac30a29cd022
   languageName: node
   linkType: hard
 
@@ -3392,6 +3597,23 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@trivago/prettier-plugin-sort-imports@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@trivago/prettier-plugin-sort-imports@npm:3.2.0"
+  dependencies:
+    "@babel/core": 7.13.10
+    "@babel/generator": 7.13.9
+    "@babel/parser": 7.14.6
+    "@babel/traverse": 7.13.0
+    "@babel/types": 7.13.0
+    javascript-natural-sort: 0.7.1
+    lodash: 4.17.21
+  peerDependencies:
+    prettier: 2.x
+  checksum: 22461433fa0dc82621713cdfb88f8f527c6c41729e9859bb7f0106ef23c35b0da591ee7fed63516be7e8df5604dc8055f0c7e200fed1ef97f44000c9fe25a890
   languageName: node
   linkType: hard
 
@@ -10256,6 +10478,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 161e2c512cc7884bc055a582c6645d9032cab88497a76123d73cb23bfb03d97a04cf7772ecdb8bd3366fc07192c2f996366f479f725c23ef073fffe03d6a586a
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-changed-files@npm:27.5.1"
@@ -11833,7 +12062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
+"lodash@npm:4.17.21, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -16270,6 +16499,13 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,7 +2285,7 @@ __metadata:
     "@babel/preset-typescript": 7.16.7
     "@commitlint/cli": 16.2.4
     "@commitlint/config-conventional": 16.2.4
-    "@graasp/sdk": "github:graasp/graasp-sdk#42/limits"
+    "@graasp/sdk": "github:graasp/graasp-sdk"
     "@graasp/translations": "github:graasp/graasp-translations.git"
     "@graasp/utils": "github:graasp/graasp-utils.git"
     "@testing-library/jest-dom": 5.16.4
@@ -2340,9 +2340,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graasp/sdk@github:graasp/graasp-sdk#42/limits":
+"@graasp/sdk@github:graasp/graasp-sdk":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=82f5b3c9a748b52513f3be815ddd822b501e999d"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=41b8c166b4a4db98259e56797f9b1f56e1b40465"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
@@ -2353,7 +2353,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: a06ae77ca3199da1cb1589f41a99c8f5e6af5e8bde9722881f79171fd97468b85a5f89ba6fcec7a4381fa81f2d4d19379e546028c33c4db74abc1916cf3a31d5
+  checksum: e3d9523f5b6ea307a1ed5dfcf7827addf2f16a8b01220dd0ad6ebcda7d28dbd93ac4caacd76f3d8159bec5f4c02395713cc874e18e795bfc7a65a2b8ea494496
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,7 +2322,6 @@ __metadata:
     jest: 28.1.0
     jest-environment-jsdom: 28.1.0
     jest-immutable-matchers: 3.0.0
-    js-cookie: 3.0.1
     microbundle-crl: 0.13.11
     mock-socket: 9.1.2
     nock: 13.2.4
@@ -2343,7 +2342,7 @@ __metadata:
 
 "@graasp/sdk@github:graasp/graasp-sdk#42/limits":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=c33a85f67736d0362ee2cbabb9250fab5e1980bb"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=82f5b3c9a748b52513f3be815ddd822b501e999d"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
@@ -2354,7 +2353,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: 8da44f403d13ff56b73897deeb729ab527152d57b65dedfbe9c2300afff509acb50fb3f097e27f1cfaca138a97aa28aeaf4931e108cf0288b4daac30a29cd022
+  checksum: a06ae77ca3199da1cb1589f41a99c8f5e6af5e8bde9722881f79171fd97468b85a5f89ba6fcec7a4381fa81f2d4d19379e546028c33c4db74abc1916cf3a31d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactors a bit the project. It takes advantage of sdk to avoid to redefine constants and types. I've also applied the prettier import. Don't be afraid of the size 🙏 

close #195 