### PR TITLE
167 split

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "jest-immutable-matchers": "3.0.0",
     "@babel/core": "7.17.10",
     "@babel/preset-env": "7.17.10",
     "@babel/preset-typescript": "7.16.7",
@@ -57,7 +58,6 @@
     "husky": "7.0.4",
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
-    "jest-immutable-matchers": "3.0.0",
     "microbundle-crl": "0.13.11",
     "mock-socket": "9.1.2",
     "nock": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "jest-immutable-matchers": "3.0.0",
     "@babel/core": "7.17.10",
     "@babel/preset-env": "7.17.10",
     "@babel/preset-typescript": "7.16.7",
@@ -58,6 +57,7 @@
     "husky": "7.0.4",
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
+    "jest-immutable-matchers": "3.0.0",
     "microbundle-crl": "0.13.11",
     "mock-socket": "9.1.2",
     "nock": "13.2.4",

--- a/src/api/axios.test.ts
+++ b/src/api/axios.test.ts
@@ -1,0 +1,77 @@
+import { UNAUTHORIZED_RESPONSE } from '../../test/constants';
+import { splitRequestByIds } from './axios';
+
+const chunkSize = 5;
+const ids = Array.from({ length: chunkSize * 3 + 1 }, (_, idx) =>
+  idx.toString(),
+);
+const buildRequest = async (chunk: typeof ids) => chunk;
+
+describe('Axios Tests', () => {
+  describe('Axios Tests', () => {
+    it('result contains the correct number of responses', async () => {
+      const zero = 0;
+      const result0 = await splitRequestByIds(
+        ids.slice(0, zero),
+        chunkSize,
+        buildRequest,
+      );
+      expect(result0.size).toEqual(zero);
+
+      const small = 2;
+      const result1 = await splitRequestByIds(
+        ids.slice(0, small),
+        chunkSize,
+        buildRequest,
+      );
+      expect(result1.size).toEqual(small);
+
+      const twice = chunkSize + 1;
+      const result2 = await splitRequestByIds(
+        ids.slice(0, twice),
+        chunkSize,
+        buildRequest,
+      );
+      expect(result2.size).toEqual(twice);
+
+      const big = ids.length;
+      const result3 = await splitRequestByIds(
+        ids.slice(0, big),
+        chunkSize,
+        buildRequest,
+      );
+      expect(result3.size).toEqual(big);
+    });
+
+    it('throws if one of the request throws', async () => {
+      await expect(
+        splitRequestByIds(ids.slice(0, 2), 1, async ([id]) => {
+          if (id === '1') {
+            throw new Error();
+          }
+          return [id];
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws if one of the request contains an error', async () => {
+      let thrownError;
+
+      try {
+        await splitRequestByIds(ids.slice(0, 2), 1, async ([id]) => {
+          if (id === '1') {
+            return UNAUTHORIZED_RESPONSE;
+          }
+          return [id];
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      // throwIfArrayContainsErrorOrReturn encapsulates the error in response.data
+      expect(thrownError).toEqual({
+        response: { data: UNAUTHORIZED_RESPONSE },
+      });
+    });
+  });
+});

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -124,17 +124,23 @@ export default configureAxios;
  * @param {string[]} ids elements' id
  * @param {number} chunkSize maximum number of ids par request
  * @param {function} buildRequest builder for the request given the chunk ids
+ * @param {boolean} [ignoreErrors=false] whether we ignore errors
  * @returns {Promise} all requests returning their data merged
  */
 export const splitRequestByIds = (
   ids: string[],
   chunkSize: number,
   buildRequest: (ids: string[]) => Promise<any>,
+  ignoreErrors = false,
 ) => {
   const shunkedIds = spliceIntoChunks(ids, chunkSize);
   return Promise.all(
     shunkedIds.map((groupedIds) => buildRequest(groupedIds)),
-  ).then((responses) =>
-    convertJs(throwIfArrayContainsErrorOrReturn(responses.flat())),
-  );
+  ).then((responses) => {
+    const result = responses.flat();
+    if (!ignoreErrors) {
+      throwIfArrayContainsErrorOrReturn(result);
+    }
+    return convertJs(throwIfArrayContainsErrorOrReturn(result));
+  });
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -141,6 +141,6 @@ export const splitRequestByIds = (
     if (!ignoreErrors) {
       throwIfArrayContainsErrorOrReturn(result);
     }
-    return convertJs(throwIfArrayContainsErrorOrReturn(result));
+    return convertJs(result);
   });
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
-import { isUserAuthenticated } from '@graasp/sdk';
+import { convertJs, isUserAuthenticated, spliceIntoChunks } from '@graasp/sdk';
 
 import { FALLBACK_TO_PUBLIC_FOR_STATUS_CODES } from '../config/constants';
 import { UserIsSignedOut } from '../config/errors';
@@ -117,3 +117,24 @@ export const throwIfArrayContainsErrorOrReturn = (array: any[]) => {
 };
 
 export default configureAxios;
+
+/**
+ * Split a given request in multiple smallest requests, so it conforms to the backend limitations
+ * The response is parsed to detect errors, and is transformed into a deep immutable data
+ * @param {string[]} ids elements' id
+ * @param {number} chunkSize maximum number of ids par request
+ * @param {function} buildRequest builder for the request given the chunk ids
+ * @returns {Promise} all requests returning their data merged
+ */
+export const splitRequestByIds = (
+  ids: string[],
+  chunkSize: number,
+  buildRequest: (ids: string[]) => Promise<any>,
+) => {
+  const shunkedIds = spliceIntoChunks(ids, chunkSize);
+  return Promise.all(
+    shunkedIds.map((groupedIds) => buildRequest(groupedIds)),
+  ).then((responses) =>
+    convertJs(throwIfArrayContainsErrorOrReturn(responses.flat())),
+  );
+};

--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -150,14 +150,25 @@ export const moveItem = async (
   });
 
 export const moveItems = async (
-  { to, id }: { id: UUID[]; to: UUID },
+  {
+    to,
+    id,
+    ids,
+  }: {
+    /**
+     * @deprecated use ids instead
+     */
+    id?: UUID[];
+    ids: UUID[];
+    to: UUID;
+  },
   { API_HOST }: QueryClientConfig,
 ) =>
   verifyAuthentication(() => {
     // send parentId if defined
     const body = { ...(to && { parentId: to }) };
     return axios
-      .post(`${API_HOST}/${buildMoveItemsRoute(id)}`, {
+      .post(`${API_HOST}/${buildMoveItemsRoute(id ?? ids)}`, {
         ...body,
       })
       .then(({ data }) => data);
@@ -191,14 +202,25 @@ export const copyPublicItem = async (
 };
 
 export const copyItems = async (
-  { id, to }: { id: UUID[]; to: UUID },
+  {
+    id,
+    ids,
+    to,
+  }: {
+    /**
+     * @deprecated use ids instead
+     */
+    id?: UUID[];
+    ids: UUID[];
+    to: UUID;
+  },
   { API_HOST }: QueryClientConfig,
 ) =>
   verifyAuthentication(() => {
     // send parentId if defined
     const body = { ...(to && { parentId: to }) };
     return axios
-      .post(`${API_HOST}/${buildCopyItemsRoute(id)}`, {
+      .post(`${API_HOST}/${buildCopyItemsRoute(id ?? ids)}`, {
         ...body,
       })
       .then(({ data }) => data);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from 'http-status-codes';
 export const STALE_TIME_MILLISECONDS = 0; // default is 0 to always refetch, can increase to trade load against consistency
 // time during which cache entry is still served while refetches are pending
 export const CACHE_TIME_MILLISECONDS = 1000 * 60 * 5; // default is 5 min
-export const CONSTANT_KEY_CACHE_TIME_MILLISECONDS = 1000 * 60 * 15; // default is 5 min
+export const CONSTANT_KEY_CACHE_TIME_MILLISECONDS = 1000 * 60 * 15; // default is 15 min
 
 export const SIGNED_OUT_USER = {};
 

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -241,8 +241,11 @@ export default (
             );
           }
 
-          return splitRequestByIds(ids, MAX_TARGETS_FOR_READ_REQUEST, (chunk) =>
-            Api.getItems(chunk, queryConfig),
+          return splitRequestByIds(
+            ids,
+            MAX_TARGETS_FOR_READ_REQUEST,
+            (chunk) => Api.getItems(chunk, queryConfig),
+            true,
           );
         },
         onSuccess: async (items: List<ItemRecord>) => {

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -1,9 +1,10 @@
 import { List } from 'immutable';
 import { QueryClient, UseQueryResult, useQuery } from 'react-query';
 
-import { convertJs } from '@graasp/sdk';
+import { MAX_TARGETS_FOR_READ_REQUEST, convertJs } from '@graasp/sdk';
 
 import * as Api from '../api';
+import { splitRequestByIds } from '../api/axios';
 import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
@@ -240,7 +241,9 @@ export default (
             );
           }
 
-          return Api.getItems(ids, queryConfig).then((data) => convertJs(data));
+          return splitRequestByIds(ids, MAX_TARGETS_FOR_READ_REQUEST, (chunk) =>
+            Api.getItems(chunk, queryConfig),
+          );
         },
         onSuccess: async (items: List<ItemRecord>) => {
           // save items in their own key

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -5,7 +5,10 @@ import { MAX_TARGETS_FOR_READ_REQUEST, convertJs } from '@graasp/sdk';
 
 import * as Api from '../api';
 import { splitRequestByIds } from '../api/axios';
-import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
+import {
+  CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+  DEFAULT_THUMBNAIL_SIZES,
+} from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
   OWN_ITEMS_KEY,
@@ -289,6 +292,7 @@ export default (
         },
         enabled: Boolean(id) && enabled,
         ...defaultQueryOptions,
+        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
       }),
 
     useRecycledItems: () =>
@@ -360,6 +364,7 @@ export default (
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
+        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
       });
     },
   };

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -5,7 +5,10 @@ import { MAX_TARGETS_FOR_READ_REQUEST, convertJs } from '@graasp/sdk';
 
 import * as Api from '../api';
 import { splitRequestByIds } from '../api/axios';
-import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
+import {
+  CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+  DEFAULT_THUMBNAIL_SIZES,
+} from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
   CURRENT_MEMBER_KEY,
@@ -88,6 +91,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       },
       ...defaultQueryOptions,
       enabled: Boolean(id) && shouldFetch,
+      cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
     });
   };
 

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -1,9 +1,10 @@
 import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 
-import { convertJs } from '@graasp/sdk';
+import { MAX_TARGETS_FOR_READ_REQUEST, convertJs } from '@graasp/sdk';
 
 import * as Api from '../api';
+import { splitRequestByIds } from '../api/axios';
 import { DEFAULT_THUMBNAIL_SIZES } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
@@ -45,7 +46,9 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     useQuery({
       queryKey: buildMembersKey(ids),
       queryFn: (): Promise<List<MemberRecord>> =>
-        Api.getMembers({ ids }, queryConfig).then((data) => convertJs(data)),
+        splitRequestByIds(ids, MAX_TARGETS_FOR_READ_REQUEST, (chunk) =>
+          Api.getMembers({ ids: chunk }, queryConfig),
+        ),
       enabled: Boolean(ids?.length),
       onSuccess: async (members: List<MemberRecord>) => {
         // save members in their own key

--- a/src/hooks/membership.ts
+++ b/src/hooks/membership.ts
@@ -1,9 +1,10 @@
 import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 
-import { convertJs } from '@graasp/sdk';
+import { MAX_TARGETS_FOR_READ_REQUEST, convertJs } from '@graasp/sdk';
 
 import * as Api from '../api';
+import { splitRequestByIds } from '../api/axios';
 import { UndefinedArgument } from '../config/errors';
 import {
   buildItemMembershipsKey,
@@ -64,8 +65,8 @@ export default (
             throw new UndefinedArgument();
           }
 
-          return Api.getMembershipsForItems(ids, queryConfig).then((data) =>
-            convertJs(data),
+          return splitRequestByIds(ids, MAX_TARGETS_FOR_READ_REQUEST, (chunk) =>
+            Api.getMembershipsForItems(chunk, queryConfig),
           );
         },
         onSuccess: async (memberships: List<List<ItemMembershipRecord>>) => {

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -790,7 +790,7 @@ describe('Items Mutations', () => {
         await waitForMutation();
       });
 
-      // Check new path are corrects
+      // Check new paths are corrects
       moved.forEach((item) => {
         const itemKey = buildItemKey(item.id);
         const path = queryClient.getQueryData<ItemRecord>(itemKey)?.path;

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -5,7 +5,13 @@ import { List } from 'immutable';
 import Cookies from 'js-cookie';
 import nock from 'nock';
 
-import { GraaspError, HttpMethod, Item, ItemType } from '@graasp/sdk';
+import {
+  GraaspError,
+  HttpMethod,
+  Item,
+  ItemType,
+  MAX_TARGETS_FOR_MODIFY_REQUEST,
+} from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
 
 import {
@@ -14,7 +20,12 @@ import {
   THUMBNAIL_BLOB_RESPONSE,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
+import {
+  mockMutation,
+  setUpTest,
+  splitEndpointByIds,
+  waitForMutation,
+} from '../../test/utils';
 import {
   buildCopyItemRoute,
   buildCopyItemsRoute,
@@ -476,16 +487,15 @@ describe('Items Mutations', () => {
 
   describe(MUTATION_KEYS.COPY_ITEMS, () => {
     const to = ITEMS.first()!.id;
-    const copied = ITEMS.slice(1);
-    const copiedIds = copied.map((x) => x.id).toArray();
-
-    const route = `/${buildCopyItemsRoute(copiedIds)}`;
 
     const mutation = () => useMutation(MUTATION_KEYS.COPY_ITEMS);
 
     const key = getKeyForParentId(to);
 
     it('copy multiple root items to first level item', async () => {
+      const copied = ITEMS.slice(1);
+      const copiedIds = copied.map((x) => x.id).toArray();
+
       // set data in cache
       ITEMS.forEach((item) => {
         const itemKey = buildItemKey(item.id);
@@ -494,15 +504,16 @@ describe('Items Mutations', () => {
 
       queryClient.setQueryData(key, List([ITEMS.get(1)!]));
 
-      const response = OK_RESPONSE;
+      // we don't care about the returned value
+      const response = ITEMS.map(() => OK_RESPONSE);
 
-      const endpoints = [
-        {
-          response,
-          method: HttpMethod.POST,
-          route,
-        },
-      ];
+      const endpoints = splitEndpointByIds(
+        copiedIds,
+        MAX_TARGETS_FOR_MODIFY_REQUEST,
+        (chunk) => `/${buildCopyItemsRoute(chunk)}`,
+        response.toJS(),
+        HttpMethod.POST,
+      );
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -530,12 +541,16 @@ describe('Items Mutations', () => {
     });
 
     it('Unauthorized to copy multiple items', async () => {
+      const nb = 2;
+      const copied = ITEMS.slice(0, nb);
+      const copiedIds = copied.map(({ id }) => id).toArray();
+      const route = `/${buildCopyItemsRoute(copiedIds)}`;
       // set data in cache
-      ITEMS.forEach((item) => {
+      copied.forEach((item) => {
         const itemKey = buildItemKey(item.id);
         queryClient.setQueryData(itemKey, item);
       });
-      queryClient.setQueryData(key, List([ITEMS.get(1)!]));
+      queryClient.setQueryData(key, List([copied.get(1)!]));
 
       const response = UNAUTHORIZED_RESPONSE;
 
@@ -685,21 +700,21 @@ describe('Items Mutations', () => {
     const to = ITEMS.first()!;
     const toId = to.id;
 
-    const moved = ITEMS.slice(1);
-    const movedIds = moved.map((x) => x.id).toArray();
-    const route = `/${buildMoveItemsRoute(movedIds)}`;
-
     const mutation = () => useMutation(MUTATION_KEYS.MOVE_ITEMS);
 
-    it('Move items from root to first level item', async () => {
+    it('Move 2 items from root to first level item', async () => {
+      const nb = 2;
+      const moved = ITEMS.slice(0, nb);
+      const movedIds = moved.map((x) => x.id).toArray();
+      const route = `/${buildMoveItemsRoute(movedIds)}`;
       // set data in cache
-      ITEMS.forEach((item) => {
+      moved.forEach((item) => {
         const itemKey = buildItemKey(item.id);
         queryClient.setQueryData(itemKey, item);
       });
-      queryClient.setQueryData(getKeyForParentId(null), ITEMS);
+      queryClient.setQueryData(getKeyForParentId(null), moved);
 
-      const response = ITEMS.map(({ id }) => id);
+      const response = moved.map(({ id }) => id);
 
       const endpoints = [
         {
@@ -718,7 +733,7 @@ describe('Items Mutations', () => {
       await act(async () => {
         await mockedMutation.mutate({
           to: toId,
-          id: movedIds,
+          ids: movedIds,
         });
         await waitForMutation();
       });
@@ -741,7 +756,9 @@ describe('Items Mutations', () => {
       ).toBeTruthy();
     });
 
-    it('Unauthorized to move multiple items', async () => {
+    it('Move many items from root to first level item', async () => {
+      const moved = ITEMS;
+      const movedIds = moved.map((x) => x.id).toArray();
       // set data in cache
       ITEMS.forEach((item) => {
         const itemKey = buildItemKey(item.id);
@@ -749,16 +766,15 @@ describe('Items Mutations', () => {
       });
       queryClient.setQueryData(getKeyForParentId(null), ITEMS);
 
-      const response = UNAUTHORIZED_RESPONSE;
+      const response = moved.map(({ id }) => id);
 
-      const endpoints = [
-        {
-          response,
-          statusCode: StatusCodes.UNAUTHORIZED,
-          method: HttpMethod.POST,
-          route,
-        },
-      ];
+      const endpoints = splitEndpointByIds(
+        movedIds,
+        MAX_TARGETS_FOR_MODIFY_REQUEST,
+        (chunk) => `/${buildMoveItemsRoute(chunk)}`,
+        response.toJS(),
+        HttpMethod.POST,
+      );
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -769,16 +785,16 @@ describe('Items Mutations', () => {
       await act(async () => {
         await mockedMutation.mutate({
           to: toId,
-          id: movedIds,
+          ids: movedIds,
         });
         await waitForMutation();
       });
 
-      // items path have not changed
+      // Check new path are corrects
       moved.forEach((item) => {
         const itemKey = buildItemKey(item.id);
         const path = queryClient.getQueryData<ItemRecord>(itemKey)?.path;
-        expect(path).toEqual(item.path);
+        expect(path).toEqual(`${to.path}.${transformIdForPath(item.id)}`);
       });
 
       // Check new parent is correctly invalidated
@@ -791,55 +807,117 @@ describe('Items Mutations', () => {
         queryClient.getQueryState(fromItemKey)?.isInvalidated,
       ).toBeTruthy();
     });
-    it('Unauthorized to move one of the items', async () => {
-      // set data in cache
-      ITEMS.forEach((item) => {
-        const itemKey = buildItemKey(item.id);
-        queryClient.setQueryData(itemKey, item);
-      });
-      queryClient.setQueryData(getKeyForParentId(null), ITEMS);
 
-      const response: (Item | GraaspError)[] = [...moved];
-      response[0] = UNAUTHORIZED_RESPONSE;
+    describe('Error handling', () => {
+      const moved = ITEMS.slice(0, 2);
+      const movedIds = moved.map((x) => x.id).toArray();
+      const route = `/${buildMoveItemsRoute(movedIds)}`;
 
-      const endpoints = [
-        {
-          response,
-          method: HttpMethod.POST,
-          route,
-        },
-      ];
-
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-
-      await act(async () => {
-        await mockedMutation.mutate({
-          to: toId,
-          id: movedIds,
+      it('Unauthorized to move multiple items', async () => {
+        // set data in cache
+        moved.forEach((item) => {
+          const itemKey = buildItemKey(item.id);
+          queryClient.setQueryData(itemKey, item);
         });
-        await waitForMutation();
+        queryClient.setQueryData(getKeyForParentId(null), moved);
+
+        const response = UNAUTHORIZED_RESPONSE;
+
+        const endpoints = [
+          {
+            response,
+            statusCode: StatusCodes.UNAUTHORIZED,
+            method: HttpMethod.POST,
+            route,
+          },
+        ];
+
+        const mockedMutation = await mockMutation({
+          endpoints,
+          mutation,
+          wrapper,
+        });
+
+        await act(async () => {
+          await mockedMutation.mutate({
+            to: toId,
+            id: movedIds,
+          });
+          await waitForMutation();
+        });
+
+        // items path have not changed
+        moved.forEach((item) => {
+          const itemKey = buildItemKey(item.id);
+          const path = queryClient.getQueryData<ItemRecord>(itemKey)?.path;
+          expect(path).toEqual(item.path);
+        });
+
+        // Check new parent is correctly invalidated
+        const toItemKey = getKeyForParentId(toId);
+        expect(
+          queryClient.getQueryState(toItemKey)?.isInvalidated,
+        ).toBeTruthy();
+
+        // Check old parent is correctly invalidated
+        const fromItemKey = getKeyForParentId(null);
+        expect(
+          queryClient.getQueryState(fromItemKey)?.isInvalidated,
+        ).toBeTruthy();
       });
 
-      // items path have not changed
-      moved.forEach((item) => {
-        const itemKey = buildItemKey(item.id);
-        const path = queryClient.getQueryData<ItemRecord>(itemKey)?.path;
-        expect(path).toEqual(item.path);
+      it('Unauthorized to move one of the items', async () => {
+        // set data in cache
+        moved.forEach((item) => {
+          const itemKey = buildItemKey(item.id);
+          queryClient.setQueryData(itemKey, item);
+        });
+        queryClient.setQueryData(getKeyForParentId(null), moved);
+
+        const response: (Item | GraaspError)[] = [...moved];
+        response[0] = UNAUTHORIZED_RESPONSE;
+
+        const endpoints = [
+          {
+            response,
+            method: HttpMethod.POST,
+            route,
+          },
+        ];
+
+        const mockedMutation = await mockMutation({
+          endpoints,
+          mutation,
+          wrapper,
+        });
+
+        await act(async () => {
+          await mockedMutation.mutate({
+            to: toId,
+            id: movedIds,
+          });
+          await waitForMutation();
+        });
+
+        // items path have not changed
+        moved.forEach((item) => {
+          const itemKey = buildItemKey(item.id);
+          const path = queryClient.getQueryData<ItemRecord>(itemKey)?.path;
+          expect(path).toEqual(item.path);
+        });
+
+        // Check new parent is correctly invalidated
+        const toItemKey = getKeyForParentId(toId);
+        expect(
+          queryClient.getQueryState(toItemKey)?.isInvalidated,
+        ).toBeTruthy();
+
+        // Check old parent is correctly invalidated
+        const fromItemKey = getKeyForParentId(null);
+        expect(
+          queryClient.getQueryState(fromItemKey)?.isInvalidated,
+        ).toBeTruthy();
       });
-
-      // Check new parent is correctly invalidated
-      const toItemKey = getKeyForParentId(toId);
-      expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
-
-      // Check old parent is correctly invalidated
-      const fromItemKey = getKeyForParentId(null);
-      expect(
-        queryClient.getQueryState(fromItemKey)?.isInvalidated,
-      ).toBeTruthy();
     });
   });
 
@@ -1109,7 +1187,7 @@ describe('Items Mutations', () => {
     const mutation = () => useMutation(MUTATION_KEYS.RECYCLE_ITEMS);
 
     it('Recycle root items', async () => {
-      const items = ITEMS.slice(2);
+      const items = ITEMS.slice(0, 2);
       const itemIds = items.map(({ id }) => id).toArray();
       const route = `/${buildRecycleItemsRoute(itemIds)}`;
 
@@ -1329,7 +1407,7 @@ describe('Items Mutations', () => {
     const mutation = () => useMutation(MUTATION_KEYS.DELETE_ITEMS);
 
     it('Delete root items', async () => {
-      const items = ITEMS.slice(2);
+      const items = ITEMS.slice(0, 2);
       const itemIds = items.map(({ id }) => id).toArray();
       const route = `/${buildDeleteItemsRoute(itemIds)}`;
 
@@ -1720,7 +1798,7 @@ describe('Items Mutations', () => {
     const mutation = () => useMutation(MUTATION_KEYS.RESTORE_ITEMS);
 
     it('Restore items', async () => {
-      const items = ITEMS.slice(2);
+      const items = ITEMS.slice(0, 2);
       const itemIds = items.map(({ id }) => id).toArray();
       const route = `/${buildRestoreItemsRoute(itemIds)}`;
 
@@ -1743,6 +1821,65 @@ describe('Items Mutations', () => {
           route,
         },
       ];
+
+      const mockedMutation = await mockMutation({
+        endpoints,
+        mutation,
+        wrapper,
+      });
+
+      await act(async () => {
+        await mockedMutation.mutate(itemIds);
+        await waitForMutation();
+      });
+
+      // verify item is still available
+      // in real cases, the path should be different
+      for (const item of items) {
+        const itemKey = buildItemKey(item.id);
+        const data = queryClient.getQueryData<ItemRecord>(itemKey);
+        expect(data).toEqualImmutable(item);
+      }
+
+      // Check parent's children key is correctly invalidated
+      // and should not contain recycled item
+      expect(
+        queryClient
+          .getQueryData<List<ItemRecord>>(recycledKey)
+          ?.filter(({ id: thisId }) => itemIds.includes(thisId)).size,
+      ).toBeFalsy();
+      expect(
+        queryClient.getQueryState(recycledKey)?.isInvalidated,
+      ).toBeTruthy();
+
+      // check original parent is invalidated
+      for (const item of items) {
+        const cKey = getKeyForParentId(getDirectParentId(item.path));
+        expect(queryClient.getQueryState(cKey)?.isInvalidated).toBeTruthy();
+      }
+    });
+
+    it('Restore many items', async () => {
+      const items = ITEMS;
+      const itemIds = items.map(({ id }) => id).toArray();
+
+      // set data in cache
+      ITEMS.forEach((item) => {
+        const itemKey = buildItemKey(item.id);
+        queryClient.setQueryData(itemKey, item);
+        const parentKey = getKeyForParentId(getDirectParentId(item.path));
+        queryClient.setQueryData(parentKey, List([item]));
+      });
+      const recycledKey = RECYCLED_ITEMS_KEY;
+      queryClient.setQueryData(recycledKey, ITEMS);
+
+      const endpoints = splitEndpointByIds(
+        itemIds,
+        MAX_TARGETS_FOR_MODIFY_REQUEST,
+        (chunk) => `/${buildRestoreItemsRoute(chunk)}`,
+        items.toJS(),
+        HttpMethod.POST,
+      );
 
       const mockedMutation = await mockMutation({
         endpoints,

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -603,6 +603,8 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(OWN_ITEMS_KEY, List(ITEMS));
+      const toItemKey = getKeyForParentId(to);
+      queryClient.setQueryData(toItemKey, List(ITEMS));
 
       const response = OK_RESPONSE;
 
@@ -636,7 +638,6 @@ describe('Items Mutations', () => {
       );
 
       // Check new parent is correctly invalidated
-      const toItemKey = getKeyForParentId(to);
       expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
 
       // Check old parent is correctly invalidated
@@ -713,6 +714,8 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(getKeyForParentId(null), moved);
+      const toItemKey = getKeyForParentId(toId);
+      queryClient.setQueryData(toItemKey, ITEMS);
 
       const response = moved.map(({ id }) => id);
 
@@ -746,7 +749,6 @@ describe('Items Mutations', () => {
       });
 
       // Check new parent is correctly invalidated
-      const toItemKey = getKeyForParentId(toId);
       expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
 
       // Check old parent is correctly invalidated
@@ -765,6 +767,8 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(getKeyForParentId(null), ITEMS);
+      const toItemKey = getKeyForParentId(toId);
+      queryClient.setQueryData(toItemKey, ITEMS);
 
       const response = moved.map(({ id }) => id);
 
@@ -798,7 +802,6 @@ describe('Items Mutations', () => {
       });
 
       // Check new parent is correctly invalidated
-      const toItemKey = getKeyForParentId(toId);
       expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
 
       // Check old parent is correctly invalidated
@@ -820,6 +823,8 @@ describe('Items Mutations', () => {
           queryClient.setQueryData(itemKey, item);
         });
         queryClient.setQueryData(getKeyForParentId(null), moved);
+        const toItemKey = getKeyForParentId(toId);
+        queryClient.setQueryData(toItemKey, ITEMS);
 
         const response = UNAUTHORIZED_RESPONSE;
 
@@ -854,7 +859,6 @@ describe('Items Mutations', () => {
         });
 
         // Check new parent is correctly invalidated
-        const toItemKey = getKeyForParentId(toId);
         expect(
           queryClient.getQueryState(toItemKey)?.isInvalidated,
         ).toBeTruthy();
@@ -873,6 +877,8 @@ describe('Items Mutations', () => {
           queryClient.setQueryData(itemKey, item);
         });
         queryClient.setQueryData(getKeyForParentId(null), moved);
+        const toItemKey = getKeyForParentId(toId);
+        queryClient.setQueryData(toItemKey, ITEMS);
 
         const response: (Item | GraaspError)[] = [...moved];
         response[0] = UNAUTHORIZED_RESPONSE;
@@ -907,7 +913,6 @@ describe('Items Mutations', () => {
         });
 
         // Check new parent is correctly invalidated
-        const toItemKey = getKeyForParentId(toId);
         expect(
           queryClient.getQueryState(toItemKey)?.isInvalidated,
         ).toBeTruthy();

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -79,12 +79,12 @@ export default (config: Partial<QueryClientConfig>) => {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       notifyOnChangeProps: 'tracked',
-      isDataEqual: isDataEqual,
+      isDataEqual,
       ...config?.defaultQueryOptions,
     },
   };
 
-  // create queryclient with given config
+  // create queryclient
   const queryClient = new QueryClient();
 
   // set up mutations given config

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -8,6 +8,8 @@ import {
   ItemMembership,
   ItemSettings,
   ItemType,
+  MAX_TARGETS_FOR_MODIFY_REQUEST,
+  MAX_TARGETS_FOR_READ_REQUEST,
   Member,
   MemberExtra,
   MemberType,
@@ -142,6 +144,21 @@ export const ITEMS: List<ItemRecord> = List([
   ITEM_4,
   ITEM_5,
   ITEM_6,
+  ...Array.from(
+    {
+      length:
+        Math.max(MAX_TARGETS_FOR_MODIFY_REQUEST, MAX_TARGETS_FOR_READ_REQUEST) +
+        1,
+    },
+    (_, idx) =>
+      createMockItem({
+        id: `item-${idx}`,
+        name: `item-${idx}`,
+        path: `item_${idx}`,
+        type: ItemType.FOLDER,
+        description: '',
+      }),
+  ),
 ]);
 
 export const MESSAGE_IDS = ['12345', '78945'];
@@ -220,6 +237,13 @@ const MEMBER_RESPONSE_2: MemberRecord = createMockMember({
 export const MEMBERS_RESPONSE: List<MemberRecord> = List([
   MEMBER_RESPONSE,
   MEMBER_RESPONSE_2,
+  ...Array.from({ length: MAX_TARGETS_FOR_READ_REQUEST }, (_, idx) =>
+    createMockMember({
+      id: idx.toString(),
+      name: `username-${idx}`,
+      email: `username-${idx}@graasp.org`,
+    }),
+  ),
 ]);
 
 export const OK_RESPONSE = {};

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -8,7 +8,7 @@ import nock from 'nock';
 import React from 'react';
 import { MutationObserverResult, QueryObserverBaseResult } from 'react-query';
 
-import { HttpMethod } from '@graasp/sdk';
+import { HttpMethod, spliceIntoChunks } from '@graasp/sdk';
 
 import configureHooks from '../src/hooks';
 import configureQueryClient from '../src/queryClient';
@@ -151,3 +151,29 @@ export const waitForMutation = async (t = 500) => {
     setTimeout(r, t);
   });
 };
+
+export const splitEndpointByIds = (
+  ids: string[],
+  chunkSize: number,
+  buildRoute: (ids: string[]) => string,
+  response: any[],
+  method?: HttpMethod,
+) =>
+  spliceIntoChunks(ids, chunkSize).map((chunk, idx) => ({
+    route: buildRoute(chunk),
+    response: response.slice(idx * chunkSize, (idx + 1) * chunkSize),
+    method,
+  }));
+
+export const splitEndpointByIdsForErrors = (
+  ids: string[],
+  chunkSize: number,
+  buildRoute: (ids: string[]) => string,
+  data: { response: any; statusCode: StatusCodes },
+  method?: HttpMethod,
+) =>
+  spliceIntoChunks(ids, chunkSize).map((chunk) => ({
+    route: buildRoute(chunk),
+    ...data,
+    method,
+  }));


### PR DESCRIPTION
This PR resolves the problem of sending too many ids (which are limited in number by the server by schema).
I think it makes sense to paginate from query client, we don't want to ask the server to return 3000 values in a single request but we don't want to handle real pagination (pages) in the front either. The limits are defined in sdk, which will sync front- and back-ends.

close #167 