### PR TITLE
fix: add query prefix on post etherpad

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -348,7 +348,10 @@ export const buildItemPublishRoute = (itemId: UUID, notification?: boolean) =>
   )}`;
 
 export const buildPostEtherpadRoute = (parentId?: UUID) =>
-  `${ETHERPAD_ROUTE}/create${parentId ? qs.stringify({ parentId }) : ''}`;
+  `${ETHERPAD_ROUTE}/create${qs.stringify(
+    { parentId },
+    { addQueryPrefix: true },
+  )}`;
 export const buildGetEtherpadRoute = (itemId: UUID) =>
   `${ETHERPAD_ROUTE}/view/${itemId}`;
 export const buildGetPublicEtherpadRoute = (itemId: UUID) =>


### PR DESCRIPTION
Bugfix: if an etherpad is created under a parent item, the `?` query prefix is missing. This PR uses the `addQueryPrefix` option to automatically enable this behaviour