### PR TITLE
fix: get parents can return partial result

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@graasp/sdk": "0.2.0",
     "@graasp/translations": "1.1.0",
-    "@graasp/utils": "github:graasp/graasp-utils.git",
     "axios": "0.27.2",
     "crypto-js": "4.1.1",
     "http-status-codes": "2.2.0",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -17,7 +17,6 @@ export function verifyAuthentication<R>(request: () => R, returnValue?: R) {
     if (returnValue) {
       return returnValue;
     }
-    console.log(isUserAuthenticated())
     throw new UserIsSignedOut();
   }
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -17,7 +17,7 @@ export function verifyAuthentication<R>(request: () => R, returnValue?: R) {
     if (returnValue) {
       return returnValue;
     }
-
+    console.log(isUserAuthenticated())
     throw new UserIsSignedOut();
   }
 

--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -133,7 +133,8 @@ export const getParents = async (
 ) => {
   const parentIds = getParentsIdsFromPath(path, { ignoreSelf: true });
   if (parentIds.length) {
-    return Promise.all(parentIds.map((id) => getItem(id, config)));
+    // use getItem to fallback to public easily
+    return Promise.allSettled<Item>(parentIds.map((id) => getItem(id, config)));
   }
   return [];
 };

--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -134,7 +134,9 @@ export const getParents = async (
   const parentIds = getParentsIdsFromPath(path, { ignoreSelf: true });
   if (parentIds.length) {
     // use getItem to fallback to public easily
-    return Promise.allSettled<Item>(parentIds.map((id) => getItem(id, config)));
+    return Promise.allSettled<Promise<Item>>(
+      parentIds.map((id) => getItem(id, config)),
+    );
   }
   return [];
 };

--- a/src/hooks/itemTag.ts
+++ b/src/hooks/itemTag.ts
@@ -1,8 +1,7 @@
 import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 
-import { convertJs } from '@graasp/sdk';
-import { isError } from '@graasp/utils';
+import { convertJs, isError } from '@graasp/sdk';
 
 import * as Api from '../api';
 import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';

--- a/src/mutations/authentication.test.ts
+++ b/src/mutations/authentication.test.ts
@@ -5,8 +5,8 @@ import Cookies from 'js-cookie';
 import nock from 'nock';
 
 import { HttpMethod } from '@graasp/sdk';
+import * as utils from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
-import * as utils from '@graasp/utils';
 
 import {
   DOMAIN,
@@ -31,9 +31,10 @@ import {
   updatePasswordRoutine,
 } from '../routines';
 
-jest.mock('@graasp/utils');
+jest.mock('@graasp/sdk');
 
 jest.spyOn(Cookies, 'get').mockReturnValue({ session: 'somesession' });
+jest.spyOn(utils, 'isUserAuthenticated').mockReturnValue(true);
 
 const email = 'myemail@email.com';
 
@@ -314,12 +315,12 @@ describe('Authentication Mutations', () => {
         await waitForMutation();
       });
 
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
 
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: signOutRoutine.SUCCESS,
         payload: { message: SUCCESS_MESSAGES.SIGN_OUT },
       });
+      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
 
       // cookie management
       expect(utils.saveUrlForRedirection).toHaveBeenCalled();

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -6,7 +6,7 @@ import {
   removeSession,
   saveUrlForRedirection,
   setCurrentSession,
-} from '@graasp/utils';
+} from '@graasp/sdk';
 
 import * as Api from '../api';
 import { CURRENT_MEMBER_KEY, MUTATION_KEYS } from '../config/keys';

--- a/src/mutations/membership.ts
+++ b/src/mutations/membership.ts
@@ -2,9 +2,8 @@ import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
 import { QueryClient } from 'react-query';
 
-import { ItemMembership, PermissionLevel } from '@graasp/sdk';
+import { ItemMembership, PermissionLevel, isError, partition } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
-import { isError, partition } from '@graasp/utils';
 
 import * as Api from '../api';
 import {

--- a/test/wsUtils.tsx
+++ b/test/wsUtils.tsx
@@ -38,7 +38,7 @@ export const setUpWsTest = (args?: {
       retry: 0,
       cacheTime: 0,
       staleTime: 0,
-      isDataEqual: isDataEqual,
+      isDataEqual,
     },
     SHOW_NOTIFICATIONS: false,
     notifier,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,6 @@ __metadata:
     "@commitlint/config-conventional": 16.2.4
     "@graasp/sdk": 0.2.0
     "@graasp/translations": 1.1.0
-    "@graasp/utils": "github:graasp/graasp-utils.git"
     "@testing-library/jest-dom": 5.16.4
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 7.0.2
@@ -2372,23 +2371,6 @@ __metadata:
   dependencies:
     i18next: 21.8.1
   checksum: 1d6fabce21ef205146c4f74b9b4b5dafc5969cf13a78cd7c4947a9b882cb22d48f3832ad6e20c21cc905b41b4809a1c2efa7ba629b12cd79bd2067df6ebd2f22
-  languageName: node
-  linkType: hard
-
-"@graasp/utils@github:graasp/graasp-utils.git":
-  version: 0.2.0
-  resolution: "@graasp/utils@https://github.com/graasp/graasp-utils.git#commit=a82c39b5ccfebb91ac9bfad978b549712ba193da"
-  dependencies:
-    "@fastify/secure-session": 5.2.0
-    aws-sdk: 2.1111.0
-    fastify: 3.29.1
-    fluent-json-schema: 3.1.0
-    immutable: 4.1.0
-    js-cookie: 3.0.1
-    qs: 6.11.0
-    slonik: 28.1.1
-    uuid: 8.3.2
-  checksum: 3eb934876453e069fe80da1f59f0298d9c99a87a816fd353ba71b41c3271f332ac6f7aedbe97979dca1390c1902a6532a2f6d4f93de126cdf976b54f0a7afef5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fix is not the best solution, as we:
- do multiple calls for getting parents -> but it's the simplest way now to fallback on the public endpoint
- we ignore partial errors -> we might have a network error in the middle but it will be ignored
Both points are solved if we use a single and dedicated endpoint.

close #224 