### PR TITLE
fix: catch avatar not found error

### DIFF
--- a/src/hooks/member.test.ts
+++ b/src/hooks/member.test.ts
@@ -9,6 +9,7 @@ import { MemberRecord } from '@graasp/sdk/frontend';
 
 import {
   AVATAR_BLOB_RESPONSE,
+  FILE_NOT_FOUND_RESPONSE,
   MEMBERS_RESPONSE,
   MEMBER_RESPONSE,
   UNAUTHORIZED_RESPONSE,
@@ -385,6 +386,27 @@ describe('Member Hooks', () => {
 
       expect(data).toBeFalsy();
       expect(isFetched).toBeFalsy();
+      // verify cache keys
+      expect(queryClient.getQueryData(key)).toBeFalsy();
+    });
+
+    it(`Error fetching avatar`, async () => {
+      const endpoints = [
+        {
+          route,
+          response: FILE_NOT_FOUND_RESPONSE,
+          statusCode: StatusCodes.NOT_FOUND,
+        },
+      ];
+      const { data, isFetched, isError } = await mockHook({
+        endpoints,
+        hook: () => hooks.useAvatar({ id: member.id }),
+        wrapper,
+      });
+
+      expect(data).toBeFalsy();
+      expect(isFetched).toBeTruthy();
+      expect(isError).toBeFalsy();
       // verify cache keys
       expect(queryClient.getQueryData(key)).toBeFalsy();
     });

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from 'axios';
+import { StatusCodes } from 'http-status-codes';
 import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 
@@ -87,9 +89,14 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
           if (!id) {
             throw new UndefinedArgument();
           }
-          return Api.downloadAvatar({ id, size }, queryConfig).then(
-            (data) => data,
-          );
+          return Api.downloadAvatar({ id, size }, queryConfig)
+            .then((data) => data)
+            .catch((error: AxiosError) => {
+              if (error.response?.status === StatusCodes.NOT_FOUND) {
+                return undefined;
+              }
+              throw error;
+            });
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -85,7 +85,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       }
       return useQuery({
         queryKey: buildAvatarKey({ id, size }),
-        queryFn: () => {
+        queryFn: (): Promise<Blob | undefined> => {
           if (!id) {
             throw new UndefinedArgument();
           }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -78,6 +78,13 @@ export const UNAUTHORIZED_RESPONSE: GraaspError = {
   statusCode: StatusCodes.UNAUTHORIZED,
   origin: 'plugin',
 };
+export const FILE_NOT_FOUND_RESPONSE: GraaspError = {
+  name: 'unauthorized',
+  code: 'GPFERR006',
+  message: 'LOCAL_FILE_NOT_FOUND',
+  statusCode: StatusCodes.NOT_FOUND,
+  origin: 'graasp-plugin-file',
+};
 
 const createMockFolderItem = (
   folderItem?: Partial<FolderItemType>,


### PR DESCRIPTION
This PR attempts to silently accept when getting an avatar fails with a 404.

There are a number of times when not being able to get an avatar is actually not an issue. Also a lot of users do not have avatars.

Other errors are re-thrown in order to be bubble them up as before.

closes #246 