### PR TITLE
fix: split get many publish info, no settled for many calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "husky install",
     "predeploy": "cd example && yarn install && yarn run build",
-    "test": "jest --silent",
+    "test": "jest",
     "test:watch": "yarn test --watchAll",
     "test:ci": "yarn && cd example && yarn && cd .. && yarn test",
     "deploy": "gh-pages -d example/build",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "husky install",
     "predeploy": "cd example && yarn install && yarn run build",
-    "test": "jest",
+    "test": "jest --silent",
     "test:watch": "yarn test --watchAll",
     "test:ci": "yarn && cd example && yarn && cd .. && yarn test",
     "deploy": "gh-pages -d example/build",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -75,13 +75,13 @@ export const splitRequestByIds = <T>(
   ).then((responses) => {
     // only get request returns
     // todo: not ideal..
-    if (!responses[0] || !responses[0]?.data) {
+    if (responses.every((r: any) => !r?.data)) {
       return null;
     }
 
     const result = responses.reduce(
       (prev, d) => ({
-        data: { ...prev.data, ...d.data },
+        data: { ...prev.data, ...(d.data ?? {}) },
         errors: prev.errors.concat(d.errors),
       }),
       { data: {}, errors: [] },

--- a/src/api/itemPublish.ts
+++ b/src/api/itemPublish.ts
@@ -1,4 +1,4 @@
-import { Item, UUID } from '@graasp/sdk';
+import { Item, ItemPublished, ResultOf, UUID } from '@graasp/sdk';
 
 import { QueryClientConfig } from '../types';
 import configureAxios, { verifyAuthentication } from './axios';
@@ -40,7 +40,7 @@ export const getItemPublishedInformation = async (
 export const getManyItemPublishedInformations = async (
   ids: UUID[],
   { API_HOST }: QueryClientConfig,
-) =>
+): Promise<ResultOf<ItemPublished>> =>
   axios
     .get(`${API_HOST}/${buildManyGetItemPublishedInformationsRoute(ids)}`)
     .then(({ data }) => data);

--- a/src/hooks/itemPublish.ts
+++ b/src/hooks/itemPublish.ts
@@ -1,7 +1,12 @@
 import { List } from 'immutable';
 import { useQuery, useQueryClient } from 'react-query';
 
-import { ItemPublished, UUID, convertJs } from '@graasp/sdk';
+import {
+  ItemPublished,
+  MAX_TARGETS_FOR_READ_REQUEST,
+  UUID,
+  convertJs,
+} from '@graasp/sdk';
 import {
   ItemPublishedRecord,
   ItemRecord,
@@ -9,6 +14,7 @@ import {
 } from '@graasp/sdk/frontend';
 
 import * as Api from '../api';
+import { splitRequestByIds } from '../api/axios';
 import { UndefinedArgument } from '../config/errors';
 import {
   buildItemPublishedInformationKey,
@@ -85,8 +91,11 @@ export default (queryConfig: QueryClientConfig) => {
       return useQuery({
         queryKey: buildManyItemPublishedInformationsKey(args.itemIds),
         queryFn: (): Promise<ResultOfRecord<ItemPublished>> =>
-          Api.getManyItemPublishedInformations(args.itemIds, queryConfig).then(
-            (data) => convertJs(data),
+          splitRequestByIds(
+            args.itemIds,
+            MAX_TARGETS_FOR_READ_REQUEST,
+            (chunk) => Api.getManyItemPublishedInformations(chunk, queryConfig),
+            true,
           ),
         onSuccess: async (publishedData) => {
           // save items in their own key

--- a/src/hooks/itemPublish.ts
+++ b/src/hooks/itemPublish.ts
@@ -91,7 +91,7 @@ export default (queryConfig: QueryClientConfig) => {
       return useQuery({
         queryKey: buildManyItemPublishedInformationsKey(args.itemIds),
         queryFn: (): Promise<ResultOfRecord<ItemPublished>> =>
-          splitRequestByIds(
+          splitRequestByIds<ItemPublished>(
             args.itemIds,
             MAX_TARGETS_FOR_READ_REQUEST,
             (chunk) => Api.getManyItemPublishedInformations(chunk, queryConfig),

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -847,8 +847,12 @@ describe('Items Mutations', () => {
     const mutation = mutations.useDeleteItems;
 
     it('Delete root items', async () => {
-      const items = ITEMS.slice(0, 2);
-      const itemIds = items.map(({ id }) => id).toArray();
+      const itemIds = [
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        RECYCLED_ITEM_DATA.get(0)!.item.id,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        RECYCLED_ITEM_DATA.get(2)!.item.id,
+      ];
       const route = `/${buildDeleteItemsRoute(itemIds)}`;
 
       // set data in cache
@@ -886,6 +890,10 @@ describe('Items Mutations', () => {
         const state = queryClient.getQueryState<ItemRecord>(itemKey);
         expect(state?.isInvalidated).toBeFalsy();
       }
+
+      expect(
+        queryClient.getQueryData(RECYCLED_ITEMS_DATA_KEY),
+      ).toEqualImmutable(List([RECYCLED_ITEM_DATA.get(1)]));
     });
 
     it('Delete child items', async () => {

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -288,100 +288,6 @@ describe('Items Mutations', () => {
     });
   });
 
-  // describe('useCopyItem', () => {
-  //   const to = ITEMS.first()!.id;
-  //   const copied = ITEMS.get(1)!;
-  //   const copiedId = copied.id;
-
-  //   const route = `/${buildCopyItemRoute(copiedId)}`;
-  //   const mutation = mutations.useCopyItem;
-
-  //   const key = getKeyForParentId(to);
-
-  //   it('Copy a single item from root item to first level item', async () => {
-  //     ITEMS.forEach((item) => {
-  //       const itemKey = buildItemKey(item.id);
-  //       queryClient.setQueryData(itemKey, item);
-  //     });
-  //     queryClient.setQueryData(key, List([ITEMS.get(1)!]));
-
-  //     const response = OK_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate({
-  //         to,
-  //         id: copiedId,
-  //       });
-  //       await waitForMutation();
-  //     });
-
-  //     // original item path have not changed
-  //     const itemKey = buildItemKey(copiedId);
-  //     expect(queryClient.getQueryData<ItemRecord>(itemKey)?.path).toEqual(
-  //       copied.path,
-  //     );
-
-  //     // Check new parent is correctly invalidated
-  //     expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
-  //   });
-
-  //   it('Unauthorized to copy a single item', async () => {
-  //     ITEMS.forEach((item) => {
-  //       const itemKey = buildItemKey(item.id);
-  //       queryClient.setQueryData(itemKey, item);
-  //     });
-  //     queryClient.setQueryData(key, List([ITEMS.get(1)!]));
-
-  //     const response = UNAUTHORIZED_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         statusCode: StatusCodes.UNAUTHORIZED,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate({
-  //         to,
-  //         id: copiedId,
-  //       });
-  //       await waitForMutation();
-  //     });
-
-  //     // original item path have not changed
-  //     const itemKey = buildItemKey(copiedId);
-  //     expect(queryClient.getQueryData<ItemRecord>(itemKey)?.path).toEqual(
-  //       copied.path,
-  //     );
-
-  //     // Check new parent is correctly invalidated
-  //     expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
-  //   });
-  // });
-
   describe('useCopyItems', () => {
     const to = ITEMS_JS[0].id;
 
@@ -434,8 +340,8 @@ describe('Items Mutations', () => {
         expect(path).toEqual(item.path);
       });
 
-      // Check new parent is correctly invalidated
-      expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
+      // Check new parent is not invalidated (because copy is async)
+      expect(queryClient.getQueryState(key)?.isInvalidated).toBeFalsy();
     });
 
     it('Unauthorized to copy multiple items', async () => {
@@ -482,118 +388,10 @@ describe('Items Mutations', () => {
         expect(path).toEqual(item.path);
       });
 
-      // check new parent is correctly invalidated
+      // check new parent is not invalidated because copy is async
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
     });
   });
-
-  // describe('useMoveItem', () => {
-  //   const to = ITEMS.first()!.id;
-  //   const moved = ITEMS.get(1)!.id;
-  //   const route = `/${buildMoveItemRoute(moved)}`;
-
-  //   const mutation = mutations.useMoveItem;
-
-  //   it('Move a single root item to first level item', async () => {
-  //     // set data in cache
-  //     ITEMS.forEach((item) => {
-  //       const itemKey = buildItemKey(item.id);
-  //       queryClient.setQueryData(itemKey, item);
-  //     });
-  //     queryClient.setQueryData(OWN_ITEMS_KEY, List(ITEMS));
-  //     const toItemKey = getKeyForParentId(to);
-  //     queryClient.setQueryData(toItemKey, List(ITEMS));
-
-  //     const response = OK_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate({
-  //         to,
-  //         id: moved,
-  //       });
-  //       await waitForMutation();
-  //     });
-
-  //     // verify cache keys
-  //     const itemKey = buildItemKey(moved);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data?.path).toEqual(
-  //       `${ITEMS.first()!.path}.${ITEMS.get(1)!.path}`,
-  //     );
-
-  //     // Check new parent is correctly invalidated
-  //     expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
-
-  //     // Check old parent is correctly invalidated
-  //     const fromItemKey = getKeyForParentId(null);
-  //     expect(
-  //       queryClient.getQueryState(fromItemKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-
-  //   it('Unauthorized to move a single item', async () => {
-  //     ITEMS.forEach((item) => {
-  //       const itemKey = buildItemKey(item.id);
-  //       queryClient.setQueryData(itemKey, item);
-  //     });
-  //     queryClient.setQueryData(getKeyForParentId(null), ITEMS);
-
-  //     const response = UNAUTHORIZED_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         statusCode: StatusCodes.UNAUTHORIZED,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate({
-  //         to,
-  //         id: moved,
-  //       });
-  //       await waitForMutation();
-  //     });
-
-  //     // verify cache keys
-  //     const itemKey = buildItemKey(moved);
-  //     expect(queryClient.getQueryData<ItemRecord>(itemKey)?.path).toEqual(
-  //       ITEMS.get(1)!.path,
-  //     );
-
-  //     // Check new parent is correctly invalidated
-  //     const toItemKey = getKeyForParentId(to);
-  //     expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
-
-  //     // Check old parent is correctly invalidated
-  //     const fromItemKey = getKeyForParentId(null);
-  //     expect(
-  //       queryClient.getQueryState(fromItemKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-  // });
 
   describe('useMoveItems', () => {
     const to = ITEMS_JS[0];
@@ -646,14 +444,12 @@ describe('Items Mutations', () => {
         expect(path).toEqual(`${to.path}.${transformIdForPath(item.id)}`);
       });
 
-      // Check new parent is correctly invalidated
-      expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
+      // Check new parent is not invalidated
+      expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeFalsy();
 
-      // Check old parent is correctly invalidated
+      // Check old parent is not invalidated
       const fromItemKey = getKeyForParentId(null);
-      expect(
-        queryClient.getQueryState(fromItemKey)?.isInvalidated,
-      ).toBeTruthy();
+      expect(queryClient.getQueryState(fromItemKey)?.isInvalidated).toBeFalsy();
     });
 
     it('Move many items from root to first level item', async () => {
@@ -700,14 +496,12 @@ describe('Items Mutations', () => {
         expect(path).toEqual(`${to.path}.${transformIdForPath(item.id)}`);
       });
 
-      // Check new parent is correctly invalidated
-      expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeTruthy();
+      // Check new parent is not invalidated
+      expect(queryClient.getQueryState(toItemKey)?.isInvalidated).toBeFalsy();
 
-      // Check old parent is correctly invalidated
+      // Check old parent is not invalidated
       const fromItemKey = getKeyForParentId(null);
-      expect(
-        queryClient.getQueryState(fromItemKey)?.isInvalidated,
-      ).toBeTruthy();
+      expect(queryClient.getQueryState(fromItemKey)?.isInvalidated).toBeFalsy();
     });
 
     describe('Error handling', () => {
@@ -827,268 +621,6 @@ describe('Items Mutations', () => {
     });
   });
 
-  // describe('useRecycleItem', () => {
-  //   const mutation = mutations.useRecycleItem;
-
-  //   it('Recycle a root item', async () => {
-  //     const item = ITEMS.first()!;
-  //     const itemId = item.id;
-  //     const route = `/${buildRecycleItemRoute(itemId)}`;
-
-  //     // set data in cache
-  //     ITEMS.forEach((i) => {
-  //       const itemKey = buildItemKey(i.id);
-  //       queryClient.setQueryData(itemKey, i);
-  //     });
-  //     queryClient.setQueryData(OWN_ITEMS_KEY, ITEMS);
-
-  //     const response = OK_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate(itemId);
-  //       await waitForMutation();
-  //     });
-
-  //     // verify item is still available
-  //     // in real cases, the path should be different
-  //     const itemKey = buildItemKey(itemId);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data).toEqualImmutable(item);
-
-  //     // Check parent's children key is correctly invalidated
-  //     // and should not contain recycled item
-  //     const childrenKey = getKeyForParentId(null);
-  //     expect(
-  //       queryClient
-  //         .getQueryData<List<ItemRecord>>(childrenKey)
-  //         ?.find(({ id }) => id === itemId),
-  //     ).toBeFalsy();
-  //     expect(
-  //       queryClient.getQueryState(childrenKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-
-  //   it('Unauthorized to recycle an item', async () => {
-  //     const item = ITEMS.first()!;
-  //     const itemId = item.id;
-  //     const route = `/${buildRecycleItemRoute(itemId)}`;
-
-  //     ITEMS.forEach((i) => {
-  //       const itemKey = buildItemKey(i.id);
-  //       queryClient.setQueryData(itemKey, i);
-  //     });
-  //     const childrenKey = getKeyForParentId(null);
-  //     queryClient.setQueryData(childrenKey, ITEMS);
-
-  //     const response = UNAUTHORIZED_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         statusCode: StatusCodes.UNAUTHORIZED,
-  //         method: HttpMethod.POST,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate(itemId);
-  //       await waitForMutation();
-  //     });
-
-  //     // verify item is still available
-  //     // in real cases, the path should be different
-  //     const itemKey = buildItemKey(itemId);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data).toEqualImmutable(item);
-
-  //     // Check parent's children key is correctly invalidated
-  //     expect(
-  //       queryClient
-  //         .getQueryData<List<ItemRecord>>(childrenKey)
-  //         ?.find(({ id }) => id === itemId),
-  //     ).toBeTruthy();
-  //     expect(
-  //       queryClient.getQueryState(childrenKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-  // });
-
-  // describe('useDeleteItem', () => {
-  //   const mutation = mutations.useDeleteItem;
-
-  //   it('Delete a root item', async () => {
-  //     const item = ITEMS.first()!;
-  //     const itemId = item.id;
-  //     const route = `/${buildDeleteItemRoute(itemId)}`;
-
-  //     // set data in cache
-  //     ITEMS.forEach((i) => {
-  //       const itemKey = buildItemKey(i.id);
-  //       queryClient.setQueryData(itemKey, i);
-  //     });
-  //     queryClient.setQueryData(RECYCLED_ITEMS_KEY, ITEMS);
-
-  //     const response = OK_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         method: HttpMethod.DELETE,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate([itemId]);
-  //       await waitForMutation();
-  //     });
-
-  //     const itemKey = buildItemKey(itemId);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data?.toJS()).toBeFalsy();
-
-  //     // Check recycled key is correctly invalidated
-  //     // and should not contain deleted item
-  //     expect(
-  //       queryClient
-  //         .getQueryData<List<ItemRecord>>(RECYCLED_ITEMS_KEY)
-  //         ?.find(({ id }) => id === itemId),
-  //     ).toBeFalsy();
-  //     expect(
-  //       queryClient.getQueryState(RECYCLED_ITEMS_KEY)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-
-  //   it('Delete an item in item', async () => {
-  //     const item = ITEMS.get(3)!;
-  //     const itemId = item.id;
-  //     const route = `/${buildDeleteItemRoute(itemId)}`;
-
-  //     // set data in cache
-  //     ITEMS.forEach((i) => {
-  //       const itemKey = buildItemKey(i.id);
-  //       queryClient.setQueryData(itemKey, i);
-  //     });
-  //     const childrenKey = RECYCLED_ITEMS_KEY;
-  //     queryClient.setQueryData(childrenKey, ITEMS);
-
-  //     const response = OK_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         method: HttpMethod.DELETE,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate([itemId]);
-  //       await waitForMutation();
-  //     });
-
-  //     // verify item is deleted
-  //     const itemKey = buildItemKey(itemId);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data?.toJS()).toBeFalsy();
-
-  //     // Check parent's children key is correctly invalidated
-  //     // and should not contain deleted item
-  //     expect(
-  //       queryClient
-  //         .getQueryData<List<ItemRecord>>(childrenKey)
-  //         ?.find(({ id }) => id === itemId),
-  //     ).toBeFalsy();
-  //     expect(
-  //       queryClient.getQueryState(childrenKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-
-  //   it('Unauthorized to delete an item', async () => {
-  //     const item = ITEMS.first()!;
-  //     const itemId = item.id;
-  //     const route = `/${buildDeleteItemRoute(itemId)}`;
-
-  //     ITEMS.forEach((i) => {
-  //       const itemKey = buildItemKey(i.id);
-  //       queryClient.setQueryData(itemKey, i);
-  //     });
-  //     const childrenKey = RECYCLED_ITEMS_KEY;
-  //     queryClient.setQueryData(childrenKey, ITEMS);
-
-  //     const response = UNAUTHORIZED_RESPONSE;
-
-  //     const endpoints = [
-  //       {
-  //         response,
-  //         statusCode: StatusCodes.UNAUTHORIZED,
-  //         method: HttpMethod.DELETE,
-  //         route,
-  //       },
-  //     ];
-
-  //     const mockedMutation = await mockMutation({
-  //       endpoints,
-  //       mutation,
-  //       wrapper,
-  //     });
-
-  //     await act(async () => {
-  //       await mockedMutation.mutate([itemId]);
-  //       await waitForMutation();
-  //     });
-
-  //     // verify item is still available
-  //     // in real cases, the path should be different
-  //     const itemKey = buildItemKey(itemId);
-  //     const data = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     expect(data).toEqualImmutable(item);
-
-  //     // Check parent's children key is correctly invalidated
-  //     expect(
-  //       queryClient
-  //         .getQueryData<List<ItemRecord>>(childrenKey)
-  //         ?.find(({ id }) => id === itemId),
-  //     ).toBeTruthy();
-  //     expect(
-  //       queryClient.getQueryState(childrenKey)?.isInvalidated,
-  //     ).toBeTruthy();
-  //   });
-  // });
-
   describe('useRecycleItems', () => {
     const mutation = mutations.useRecycleItems;
 
@@ -1141,9 +673,9 @@ describe('Items Mutations', () => {
           .getQueryData<List<ItemRecord>>(childrenKey)
           ?.filter(({ id: thisId }) => itemIds.includes(thisId)).size,
       ).toBeFalsy();
-      expect(
-        queryClient.getQueryState(childrenKey)?.isInvalidated,
-      ).toBeTruthy();
+
+      // check key is not invalidated
+      expect(queryClient.getQueryState(childrenKey)?.isInvalidated).toBeFalsy();
     });
 
     it('Recycle child items', async () => {
@@ -1188,11 +720,10 @@ describe('Items Mutations', () => {
         expect(data).toEqualImmutable(ITEMS.find(({ id }) => id === itemId));
       }
 
-      // Check parent's children key is correctly invalidated
+      // Check parent's children key is not invalidated
       // and should not contain recycled item
-      expect(
-        queryClient.getQueryState(childrenKey)?.isInvalidated,
-      ).toBeTruthy();
+      expect(queryClient.getQueryState(childrenKey)?.isInvalidated).toBeFalsy();
+
       expect(
         queryClient
           .getQueryData<List<ItemRecord>>(childrenKey)
@@ -1352,7 +883,7 @@ describe('Items Mutations', () => {
       for (const itemId of itemIds) {
         const itemKey = buildItemKey(itemId);
         const state = queryClient.getQueryState<ItemRecord>(itemKey);
-        expect(state?.isInvalidated).toBeTruthy();
+        expect(state?.isInvalidated).toBeFalsy();
       }
     });
 
@@ -1393,7 +924,7 @@ describe('Items Mutations', () => {
       for (const itemId of itemIds) {
         const itemKey = buildItemKey(itemId);
         const state = queryClient.getQueryState<ItemRecord>(itemKey);
-        expect(state?.isInvalidated).toBeTruthy();
+        expect(state?.isInvalidated).toBeFalsy();
       }
     });
 

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -360,50 +360,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const useRecycleItems = () =>
     useMutation<void, unknown, UUID[]>(RECYCLE_ITEMS);
 
-  // queryClient.setMutationDefaults(DELETE_ITEM, {
-  //   mutationFn: ([itemId]) => Api.deleteItem(itemId, queryConfig),
-
-  //   onMutate: async ([itemId]) => {
-  //     const key = RECYCLED_ITEMS_KEY;
-  //     const data = queryClient.getQueryData(key) as List<ItemRecord>;
-  //     queryClient.setQueryData(
-  //       key,
-  //       data?.filter(({ id }) => id !== itemId),
-  //     );
-  //     const previousItems = {
-  //       parent: data,
-  //       item: await mutateItem({ id: itemId, value: null }),
-  //     };
-  //     return previousItems;
-  //   },
-  //   onSuccess: () => {
-  //     notifier?.({
-  //       type: deleteItemRoutine.SUCCESS,
-  //       payload: { message: SUCCESS_MESSAGES.DELETE_ITEM },
-  //     });
-  //   },
-  //   onError: (error, [itemId], context) => {
-  //     const itemData = context.item;
-
-  //     if (itemData) {
-  //       const itemKey = buildItemKey(itemId);
-  //       queryClient.setQueryData(itemKey, context.item);
-  //       queryClient.setQueryData(RECYCLED_ITEMS_KEY, context.parent);
-  //     }
-  //     notifier?.({ type: deleteItemRoutine.FAILURE, payload: { error } });
-  //   },
-  //   onSettled: (_data, _error, [itemId], context) => {
-  //     const itemData = context.item;
-
-  //     if (itemData) {
-  //       const itemKey = buildItemKey(itemId);
-  //       queryClient.invalidateQueries(itemKey);
-  //       queryClient.invalidateQueries(RECYCLED_ITEMS_KEY);
-  //     }
-  //   },
-  // });
-  // const useDeleteItem = () => useMutation<void, unknown, UUID[]>(DELETE_ITEM);
-
   queryClient.setMutationDefaults(DELETE_ITEMS, {
     mutationFn: (itemIds) =>
       splitRequestByIds(itemIds, MAX_TARGETS_FOR_MODIFY_REQUEST, (chunk) =>
@@ -457,49 +413,8 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
       notifier?.({ type: deleteItemsRoutine.FAILURE, payload: { error } });
     },
-    onSettled: (_data, _error, itemIds: UUID[], context) => {
-      const itemPath = context[itemIds[0]]?.path;
-
-      itemIds.forEach((id) => {
-        const itemKey = buildItemKey(id);
-        queryClient.invalidateQueries(itemKey);
-      });
-
-      if (itemPath) {
-        queryClient.invalidateQueries(RECYCLED_ITEMS_DATA_KEY);
-      }
-    },
   });
   const useDeleteItems = () => useMutation<void, unknown, UUID[]>(DELETE_ITEMS);
-
-  // queryClient.setMutationDefaults(COPY_ITEM, {
-  //   mutationFn: (payload) => Api.copyItem(payload, queryConfig),
-  //   // cannot mutate because it needs the id
-  //   onSuccess: () => {
-  //     notifier?.({
-  //       type: copyItemRoutine.REQUEST,
-  //       // TODO: CHANGE FOR PENDING TEXT
-  //       payload: { message: SUCCESS_MESSAGES.COPY_ITEM },
-  //     });
-  //   },
-  //   onError: (error) => {
-  //     console.log(error);
-  //     notifier?.({ type: copyItemRoutine.FAILURE, payload: { error } });
-  //   },
-  //   onSettled: (_newItem, _err, payload) => {
-  //     const parentKey = getKeyForParentId(payload.to);
-  //     queryClient.invalidateQueries(parentKey);
-  //   },
-  // });
-  // const useCopyItem = () =>
-  //   useMutation<
-  //     void,
-  //     unknown,
-  //     {
-  //       id: UUID;
-  //       to: UUID;
-  //     }
-  //   >(COPY_ITEM);
 
   queryClient.setMutationDefaults(COPY_ITEMS, {
     mutationFn: ({ ids, to }: { ids: UUID[]; to?: UUID }) =>
@@ -531,93 +446,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
         to?: UUID;
       }
     >(COPY_ITEMS);
-
-  // queryClient.setMutationDefaults(MOVE_ITEM, {
-  //   mutationFn: (payload) => Api.moveItem(payload, queryConfig),
-  //   onMutate: async ({ id: itemId, to }) => {
-  //     const itemKey = buildItemKey(itemId);
-  //     const itemData = queryClient.getQueryData<ItemRecord>(itemKey);
-  //     const toData = queryClient.getQueryData<ItemRecord>(buildItemKey(to));
-
-  //     const context: {
-  //       targetParent?: unknown;
-  //       originalParent?: unknown;
-  //       item?: unknown;
-  //     } = {};
-
-  //     if (itemData?.has('path') && toData?.has('path')) {
-  //       const newPath = buildPath({
-  //         prefix: toData.path,
-  //         ids: [itemId],
-  //       });
-
-  //       // update item
-  //       context.item = itemData;
-  //       const updatedItem = itemData.set('path', newPath);
-  //       queryClient.setQueryData(itemKey, updatedItem);
-
-  //       // add item to target item children
-  //       context.targetParent = await mutateParentChildren({
-  //         id: to,
-  //         value: (old: List<Item>) => old?.push(updatedItem?.toJS() as Item),
-  //       });
-
-  //       // remove item from current parent children
-  //       const oldPath = itemData.path;
-  //       context.originalParent = await mutateParentChildren({
-  //         childPath: oldPath,
-  //         value: (old: List<ItemRecord>) =>
-  //           old?.filter(({ id }) => id !== itemId),
-  //       });
-  //     }
-  //     return context;
-  //   },
-  //   onSuccess: () => {
-  //     notifier?.({
-  //       type: moveItemRoutine.TRIGGER,
-  //       // TODO: CHANGE FOR PENDING TEXT
-  //       payload: { message: SUCCESS_MESSAGES.MOVE_ITEM },
-  //     });
-  //   },
-  //   // If the mutation fails, use the context returned from onMutate to roll back
-  //   onError: (error, { id, to }, context) => {
-  //     const itemKey = buildItemKey(id);
-  //     queryClient.setQueryData(itemKey, context.item);
-
-  //     const parentKey = getKeyForParentId(to);
-  //     queryClient.setQueryData(parentKey, context.targetParent);
-
-  //     const itemData = context.item;
-  //     if (itemData && context.originalParent) {
-  //       const pKey = getKeyForParentId(getDirectParentId(itemData.path));
-  //       queryClient.setQueryData(pKey, context.originalParent);
-  //     }
-  //     notifier?.({ type: moveItemRoutine.FAILURE, payload: { error } });
-  //   },
-  //   // Always refetch after error or success:
-  //   onSettled: (_newItem, _err, { id, to }, context) => {
-  //     // Invalidate new parent
-  //     const newParentKey = getKeyForParentId(to);
-  //     queryClient.invalidateQueries(newParentKey);
-
-  //     // Invalidate old parent
-  //     const oldParentKey = getKeyForParentId(context.originalParent.id);
-  //     queryClient.invalidateQueries(oldParentKey);
-
-  //     // Invalidate moved item
-  //     const itemKey = buildItemKey(id);
-  //     queryClient.invalidateQueries(itemKey);
-  //   },
-  // });
-  // const useMoveItem = () =>
-  //   useMutation<
-  //     void,
-  //     unknown,
-  //     {
-  //       id?: UUID;
-  //       to: UUID;
-  //     }
-  //   >(MOVE_ITEM);
 
   queryClient.setMutationDefaults(MOVE_ITEMS, {
     mutationFn: ({ ids, to }: { ids: UUID[]; to: UUID }) =>
@@ -696,23 +524,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
         }
       });
       notifier?.({ type: moveItemsRoutine.FAILURE, payload: { error } });
-    },
-    // Always refetch after error or success:
-    onSettled: (_newItem, _err, { id, ids, to }, context) => {
-      const itemIds = id ?? ids;
-      // Invalidate new parent
-      const newParentKey = getKeyForParentId(to);
-      queryClient.invalidateQueries(newParentKey);
-
-      // Invalidate old parent
-      const oldParentKey = getKeyForParentId(context.originalParent.id);
-      queryClient.invalidateQueries(oldParentKey);
-
-      itemIds.forEach((itemId: UUID) => {
-        // Invalidate moved item
-        const itemKey = buildItemKey(itemId);
-        queryClient.invalidateQueries(itemKey);
-      });
     },
   });
   const useMoveItems = () =>

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -11,7 +11,7 @@ import {
   UUID,
   convertJs,
 } from '@graasp/sdk';
-import { ItemRecord } from '@graasp/sdk/frontend';
+import { ItemRecord, RecycledItemDataRecord } from '@graasp/sdk/frontend';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
 
 import * as Api from '../api';
@@ -317,13 +317,14 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     onMutate: async (itemIds: UUID[]) => {
       // get path from first item
       const itemKey = RECYCLED_ITEMS_DATA_KEY;
-      const items = queryClient.getQueryData(itemKey) as List<ItemRecord>;
+      const itemData =
+        queryClient.getQueryData<List<RecycledItemDataRecord>>(itemKey);
       queryClient.setQueryData(
-        RECYCLED_ITEMS_DATA_KEY,
-        items?.filter(({ id }) => !itemIds.includes(id)),
+        itemKey,
+        itemData?.filter(({ item: { id } }) => !itemIds.includes(id)),
       );
       const previousItems: any = {
-        parent: items,
+        parent: itemData,
       };
 
       itemIds.forEach(async (id) => {
@@ -332,7 +333,6 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: (result) => {
-      console.log(result);
       const errors = result?.filter(
         (r: Item | GraaspError) => (r as GraaspError).statusCode,
       );

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -332,10 +332,11 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return previousItems;
     },
     onSuccess: (result) => {
-      const errors = result.filter(
+      console.log(result);
+      const errors = result?.filter(
         (r: Item | GraaspError) => (r as GraaspError).statusCode,
       );
-      if (!errors.isEmpty()) {
+      if (errors && !errors.isEmpty()) {
         // todo: revert deleted items
         return notifier?.({
           type: deleteItemsRoutine.FAILURE,
@@ -631,10 +632,12 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     onMutate: async (itemIds) => {
       const key = RECYCLED_ITEMS_DATA_KEY;
       const items = queryClient.getQueryData(key) as List<Item>;
-      queryClient.setQueryData(
-        key,
-        items.filter(({ id }) => !itemIds.includes(id)),
-      );
+      if (items) {
+        queryClient.setQueryData(
+          key,
+          items.filter(({ id }) => !itemIds.includes(id)),
+        );
+      }
       return items;
     },
     onSuccess: (_data, itemIds) => {

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -196,10 +196,18 @@ export const ITEMS: List<ItemRecord> = convertJs(ITEMS_JS);
 
 export const MENTION_IDS = ['12345', '78945'];
 
-export const RECYCLED_ITEM_DATA: RecycledItemDataRecord = convertJs([
+export const RECYCLED_ITEM_DATA: List<RecycledItemDataRecord> = convertJs([
   {
     id: `recycle-item-id`,
     item: ITEM_1,
+  },
+  {
+    id: `recycle-item-id-1`,
+    item: ITEM_2,
+  },
+  {
+    id: `recycle-item-id-2`,
+    item: ITEM_3,
   },
 ]);
 


### PR DESCRIPTION
This PR fixes:
- GET collection's information for more than 15 ids
- Remove commented code
- Remove some invalidation due to some endpoints being async (copy, move, delete, recycle, restore many). Instead the `onMutation` callback will positively update the view, and websockets should do the job

close #277 