### PR TITLE
refactor: update useParents types, enable back tests

### DIFF
--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -63,13 +63,6 @@ export const postItem = async (
       .then(({ data }) => data),
   );
 
-// export const deleteItem = async (id: UUID, { API_HOST }: QueryClientConfig) =>
-//   verifyAuthentication(() =>
-//     axios
-//       .delete(`${API_HOST}/${buildDeleteItemRoute(id)}`)
-//       .then(({ data }) => data),
-//   );
-
 export const deleteItems = async (
   ids: UUID[],
   { API_HOST }: QueryClientConfig,
@@ -107,16 +100,19 @@ export const getChildren = async (
     .then(({ data }) => data);
 
 export const getParents = async (
-  { id, path }: { id: UUID; path: string },
+  { id, path }: { id: UUID; path?: string },
   { API_HOST }: QueryClientConfig,
 ): Promise<Item[]> => {
-  const parentIds = getParentsIdsFromPath(path, { ignoreSelf: true });
-  if (parentIds.length) {
-    return axios
-      .get(`${API_HOST}/${buildGetItemParents(id)}`)
-      .then(({ data }) => data);
+  // shortcut to prevent fetching parents if path shows that item is a root
+  if (path) {
+    const parentIds = getParentsIdsFromPath(path, { ignoreSelf: true });
+    if (!parentIds.length) {
+      return [];
+    }
   }
-  return [];
+  return axios
+    .get(`${API_HOST}/${buildGetItemParents(id)}`)
+    .then(({ data }) => data);
 };
 
 export const getDescendants = async (
@@ -126,18 +122,6 @@ export const getDescendants = async (
   axios
     .get(`${API_HOST}/${buildGetItemDescendants(id)}`)
     .then(({ data }) => data);
-
-// export const moveItem = async (
-//   { to, id }: { id: UUID; to: UUID },
-//   { API_HOST }: QueryClientConfig,
-// ) =>
-//   verifyAuthentication(() => {
-//     // send parentId if defined
-//     const body = { ...(to && { parentId: to }) };
-//     return axios.post(`${API_HOST}/${buildMoveItemRoute(id)}`, {
-//       ...body,
-//     });
-//   });
 
 export const moveItems = async (
   {
@@ -156,18 +140,6 @@ export const moveItems = async (
       ...body,
     });
   });
-
-// export const copyItem = async (
-//   { id, to }: { id: UUID; to: UUID },
-//   { API_HOST }: QueryClientConfig,
-// ) =>
-//   verifyAuthentication(() => {
-//     // send parentId if defined
-//     const body = { ...(to && { parentId: to }) };
-//     return axios.post(`${API_HOST}/${buildCopyItemRoute(id)}`, {
-//       ...body,
-//     });
-//   });
 
 export const copyItems = async (
   {
@@ -222,13 +194,6 @@ export const getRecycledItemsData = async ({ API_HOST }: QueryClientConfig) =>
       .get<Item[]>(`${API_HOST}/${GET_RECYCLED_ITEMS_DATA_ROUTE}`)
       .then(({ data }) => data),
   );
-
-// export const recycleItem = async (id: UUID, { API_HOST }: QueryClientConfig) =>
-//   verifyAuthentication(() =>
-//     axios
-//       .post(`${API_HOST}/${buildRecycleItemRoute(id)}`)
-//       .then(({ data }) => data),
-//   );
 
 export const recycleItems = async (
   ids: UUID[],

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -36,7 +36,7 @@ export const buildMembersKey = (ids: UUID[]) => [
   MEMBERS_KEY,
   hashItemsIds(ids),
 ];
-export const buildItemParentsKey = (id: UUID) => [ITEMS_KEY, 'parents', id];
+export const buildItemParentsKey = (id?: UUID) => [ITEMS_KEY, 'parents', id];
 export const CHATS_KEY = 'chats';
 export const buildItemChatKey = (id: UUID) => [CHATS_KEY, id];
 export const EXPORT_CHATS_KEY = 'exportChats';

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -182,7 +182,7 @@ export const buildItemValidationGroupsKey = (id: UUID) => [
 ];
 
 export const buildActionsKey = (args: {
-  itemId: UUID;
+  itemId?: UUID;
   view: string;
   requestedSampleSize: number;
 }) => [

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -169,67 +169,32 @@ export default (
       );
     },
 
-    // TODO: GET ITEMS WITH TAGS -> used to get pinned items
-    // useItemsChildren: (
-    //   ids: UUID[],
-    //   options?: {
-    //     enabled?: boolean;
-    //     ordered?: boolean;
-    //     getUpdates?: boolean;
-    //     placeholderData?: List<List<ItemRecord>>;
-    //   },
-    // ) => {
-    //   const enabled = options?.enabled ?? true;
-    //   const ordered = options?.ordered ?? true;
-
-    //   return useQuery({
-    //     queryKey: buildItemsChildrenKey(ids),
-    //     queryFn: (): Promise<ResultOfRecord<Item[]>> =>
-    //       Promise.all(
-    //         ids.map((id) =>
-    //           Api.getChildren(id, ordered, queryConfig).then((data) =>
-    //             convertJs(data),
-    //           ),
-    //         ),
-    //       ).then((items) => List(items)),
-    //     onSuccess: async (items) => {
-    //       /* Because the query function loops over the ids, this returns an array
-    //       of immutable list of items, each list correspond to an item and contains
-    //       their children */
-    //       if (items.size) {
-    //         // For each item, get the list of its childrens
-    //         items.forEach((item) => {
-    //           // If the item has children, save them in query client
-    //           if (item.size) {
-    //             item.forEach((child) => {
-    //               const { id } = child;
-    //               queryClient.setQueryData(buildItemKey(id), child);
-    //             });
-    //           }
-    //         });
-    //       }
-    //     },
-    //     ...defaultQueryOptions,
-    //     enabled: Boolean(ids) && enabled,
-    //     placeholderData: options?.placeholderData,
-    //   });
-    // },
-
+    /**
+     * return parents for given item id
+     * @param id {string} item id
+     * @param path {string} item path, used to prevent fetching if no parent is defined
+     * @returns immutable list of parent items
+     */
     useParents: ({
       id,
       path,
       enabled,
     }: {
-      id: UUID;
-      path: string;
+      id?: UUID;
+      path?: string;
       enabled?: boolean;
     }) =>
       useQuery({
         queryKey: buildItemParentsKey(id),
-        queryFn: (): Promise<List<ItemRecord>> =>
-          Api.getParents({ id, path }, queryConfig).then((items) =>
+        queryFn: (): Promise<List<ItemRecord>> => {
+          if (!id) {
+            throw new UndefinedArgument();
+          }
+
+          return Api.getParents({ id, path }, queryConfig).then((items) =>
             convertJs(items),
-          ),
+          );
+        },
         onSuccess: async (items: List<ItemRecord>) => {
           if (items?.size) {
             // save items in their own key
@@ -401,36 +366,6 @@ export default (
         },
         ...defaultQueryOptions,
       }),
-
-    // useItemsWithTag: (
-    //   tagId?: UUID,
-    //   options?: { placeholderData?: List<ItemRecord> },
-    // ) => {
-    //   const placeholderData = options?.placeholderData;
-    //   return useQuery({
-    //     queryKey: buildPublicItemsWithTagKey(tagId),
-    //     queryFn: (): Promise<List<ItemRecord>> => {
-    //       if (!tagId) {
-    //         throw new UndefinedArgument();
-    //       }
-
-    //       return Api.getPublicItemsWithTag({ tagId }, queryConfig).then(
-    //         (data) => convertJs(data),
-    //       );
-    //     },
-    //     onSuccess: async (items: List<ItemRecord>) => {
-    //       // save items in their own key
-    //       // eslint-disable-next-line no-unused-expressions
-    //       items?.forEach(async (item) => {
-    //         const { id } = item;
-    //         queryClient.setQueryData(buildItemKey(id), item);
-    //       });
-    //     },
-    //     ...defaultQueryOptions,
-    //     placeholderData,
-    //     enabled: Boolean(tagId),
-    //   });
-    // },
 
     useItemThumbnail: ({
       id,

--- a/src/ws/hooks/item.test.ts
+++ b/src/ws/hooks/item.test.ts
@@ -170,7 +170,7 @@ describe('Ws Item Hooks', () => {
       expect(
         queryClient
           .getQueryData<List<ItemRecord>>(childrenKey)
-          ?.find(({ id }) => id === targetItem.id),
+          ?.find(({ id }: ItemRecord) => id === targetItem.id),
       ).toBeFalsy();
     });
 


### PR DESCRIPTION
This PR improves `useParents` type. It mainly allows `path` to be optional.
Tests are also fixed and enabled back.
It also includes a change for an optional id for `useActions`