### PR TITLE
fix: use `categoryId` instead of `categoryIds`

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -341,7 +341,7 @@ export const buildGetAllPublishedItemsRoute = (categoryIds?: UUID[]) =>
   `${ITEMS_ROUTE}/${COLLECTIONS_ROUTE}${
     categoryIds?.length
       ? qs.stringify(
-          { categoryIds },
+          { categoryId: categoryIds },
           {
             arrayFormat: 'repeat',
             addQueryPrefix: true,


### PR DESCRIPTION
Related to https://github.com/graasp/graasp/pull/427. 

We decided to fix the bug in the queryClient to stay consistent with the fact that all queryParams are singular when they are an array.