### PR TITLE
fix: extract etherpad object from api response

### DIFF
--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -275,6 +275,8 @@ export const getEtherpad = (
   { itemId, mode }: { itemId: UUID; mode: 'read' | 'write' },
   { API_HOST }: QueryClientConfig,
 ) =>
-  axios.get(`${API_HOST}/${buildGetEtherpadRoute(itemId)}`, {
-    params: { mode },
-  });
+  axios
+    .get(`${API_HOST}/${buildGetEtherpadRoute(itemId)}`, {
+      params: { mode },
+    })
+    .then(({ data }) => data);


### PR DESCRIPTION
This PR fixes a bug where the result data was not extracted from the axios response in etherpad queries