### PR TITLE
fix: export public getAllPublishedItems route

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "microbundle-crl": "0.13.11",
     "mock-socket": "9.2.1",
     "nock": "13.3.1",
-    "prettier": "3.0.0",
+    "prettier": "2.8",
     "react-test-renderer": "17.0.2",
     "standard-version": "9.5.0",
     "ts-jest": "29.1.0",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -409,6 +409,7 @@ export const API_ROUTES = {
   buildGetMembersBy,
   buildGetMembersRoute,
   buildGetPlanRoute,
+  buildGetAllPublishedItemsRoute,
   buildGetPublishedItemsForMemberRoute,
   buildImportH5PRoute,
   buildImportZipRoute,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,7 +3434,7 @@ __metadata:
     microbundle-crl: 0.13.11
     mock-socket: 9.2.1
     nock: 13.3.1
-    prettier: 3.0.0
+    prettier: 2.8
     qs: 6.11.2
     react-query: 3.39.3
     react-test-renderer: 17.0.2
@@ -16278,12 +16278,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0":
-  version: 3.0.0
-  resolution: "prettier@npm:3.0.0"
+"prettier@npm:2.8":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
   bin:
-    prettier: bin/prettier.cjs
-  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
+    prettier: bin-prettier.js
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR exposes the `buildGetAllPublishedItems` builder function on the `API_ROUTE` named export. 

This public export will be used to configure route intercepts in cypress for example. 