### PR TITLE
feat: add mobile sign up hooks

### DIFF
--- a/src/api/authentication.ts
+++ b/src/api/authentication.ts
@@ -6,6 +6,7 @@ import configureAxios, { verifyAuthentication } from './axios';
 import {
   MOBILE_SIGN_IN_ROUTE,
   MOBILE_SIGN_IN_WITH_PASSWORD_ROUTE,
+  MOBILE_SIGN_UP_ROUTE,
   SIGN_IN_ROUTE,
   SIGN_IN_WITH_PASSWORD_ROUTE,
   SIGN_OUT_ROUTE,
@@ -58,6 +59,11 @@ export const mobileSignInWithPassword = async (
     .then(({ data }) => data);
 
 export const signUp = async (
-  payload: { name: string; email: string },
+  payload: { name: string; email: string; captcha: string },
   { API_HOST }: QueryClientConfig,
 ): Promise<void> => axios.post(`${API_HOST}/${SIGN_UP_ROUTE}`, payload);
+
+export const mobileSignUp = async (
+  payload: { name: string; email: string; challenge: string; captcha: string },
+  { API_HOST }: QueryClientConfig,
+): Promise<void> => axios.post(`${API_HOST}/${MOBILE_SIGN_UP_ROUTE}`, payload);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -156,6 +156,7 @@ export const buildDownloadItemThumbnailRoute = ({
   )}`;
 
 export const GET_CURRENT_MEMBER_ROUTE = `${MEMBERS_ROUTE}/current`;
+export const MOBILE_SIGN_UP_ROUTE = `m/register`;
 export const MOBILE_SIGN_IN_ROUTE = `m/login`;
 export const MOBILE_SIGN_IN_WITH_PASSWORD_ROUTE = `m/login-password`;
 export const SIGN_IN_ROUTE = `login`;

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -159,6 +159,30 @@ export default (queryConfig: QueryClientConfig) => {
       },
     );
 
+  const useMobileSignUp = () =>
+    useMutation(
+      (payload: {
+        name: string;
+        email: string;
+        challenge: string;
+        captcha: string;
+      }) => Api.mobileSignUp(payload, queryConfig),
+      {
+        onSuccess: () => {
+          notifier?.({
+            type: signUpRoutine.SUCCESS,
+            payload: { message: SUCCESS_MESSAGES.SIGN_UP },
+          });
+        },
+        onError: (error: Error) => {
+          notifier?.({
+            type: signUpRoutine.FAILURE,
+            payload: { error },
+          });
+        },
+      },
+    );
+
   const useSignOut = () => {
     const queryClient = useQueryClient();
     return useMutation((_currentMemberId: UUID) => Api.signOut(queryConfig), {
@@ -227,6 +251,7 @@ export default (queryConfig: QueryClientConfig) => {
     useSignInWithPassword,
     useSignOut,
     useSignUp,
+    useMobileSignUp,
     useUpdatePassword,
     useMobileSignIn,
     useMobileSignInWithPassword,


### PR DESCRIPTION
This PR adds:
- hooks to register using the mobile endpoints
- tests for the mobile signin and register endpoints