### PR TITLE
fix: use more explicit error message when signinwithpassword without a password set

### DIFF
--- a/src/mutations/authentication.test.ts
+++ b/src/mutations/authentication.test.ts
@@ -13,6 +13,7 @@ import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import {
   MOBILE_SIGN_IN_ROUTE,
   MOBILE_SIGN_IN_WITH_PASSWORD_ROUTE,
+  MOBILE_SIGN_UP_ROUTE,
   SIGN_IN_ROUTE,
   SIGN_IN_WITH_PASSWORD_ROUTE,
   SIGN_OUT_ROUTE,
@@ -61,6 +62,7 @@ describe('Authentication Mutations', () => {
   afterEach(() => {
     queryClient.clear();
     nock.cleanAll();
+    jest.clearAllMocks();
   });
 
   describe('useSignIn', () => {
@@ -427,7 +429,7 @@ describe('Authentication Mutations', () => {
     });
   });
   describe('useMobileSignUp', () => {
-    const route = `/${SIGN_UP_ROUTE}`;
+    const route = `/${MOBILE_SIGN_UP_ROUTE}`;
     const mutation = mutations.useMobileSignUp;
     const name = 'name';
 

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -94,11 +94,12 @@ export default (queryConfig: QueryClientConfig) => {
                 error: newError,
               },
             });
+          } else {
+            notifier?.({
+              type: signInWithPasswordRoutine.FAILURE,
+              payload: { error },
+            });
           }
-          notifier?.({
-            type: signInWithPasswordRoutine.FAILURE,
-            payload: { error },
-          });
         },
       },
     );

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -1,9 +1,7 @@
 import { UUID, saveUrlForRedirection } from '@graasp/sdk';
 import { Password } from '@graasp/sdk/frontend';
-import { FAILURE_MESSAGES, SUCCESS_MESSAGES } from '@graasp/translations';
+import { SUCCESS_MESSAGES } from '@graasp/translations';
 
-import { AxiosError } from 'axios';
-import { StatusCodes } from 'http-status-codes';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
@@ -80,26 +78,11 @@ export default (queryConfig: QueryClientConfig) => {
           });
           queryClient.resetQueries();
         },
-        onError: (error: Error | AxiosError) => {
-          if (
-            error instanceof AxiosError &&
-            error.response?.status === StatusCodes.NOT_ACCEPTABLE
-          ) {
-            // deep copy the error
-            const newError = JSON.parse(JSON.stringify(error));
-            newError.message = FAILURE_MESSAGES.MEMBER_WITHOUT_PASSWORD;
-            notifier?.({
-              type: signInWithPasswordRoutine.FAILURE,
-              payload: {
-                error: newError,
-              },
-            });
-          } else {
-            notifier?.({
-              type: signInWithPasswordRoutine.FAILURE,
-              payload: { error },
-            });
-          }
+        onError: (error: Error) => {
+          notifier?.({
+            type: signInWithPasswordRoutine.FAILURE,
+            payload: { error },
+          });
         },
       },
     );
@@ -123,25 +106,10 @@ export default (queryConfig: QueryClientConfig) => {
           queryClient.resetQueries();
         },
         onError: (error: Error) => {
-          if (
-            error instanceof AxiosError &&
-            error.response?.status === StatusCodes.NOT_ACCEPTABLE
-          ) {
-            // deep copy the error
-            const newError = JSON.parse(JSON.stringify(error));
-            newError.message = FAILURE_MESSAGES.MEMBER_WITHOUT_PASSWORD;
-            notifier?.({
-              type: signInWithPasswordRoutine.FAILURE,
-              payload: {
-                error: newError,
-              },
-            });
-          } else {
-            notifier?.({
-              type: signInWithPasswordRoutine.FAILURE,
-              payload: { error },
-            });
-          }
+          notifier?.({
+            type: signInWithPasswordRoutine.FAILURE,
+            payload: { error },
+          });
         },
       },
     );

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -80,10 +80,10 @@ export default (queryConfig: QueryClientConfig) => {
           });
           queryClient.resetQueries();
         },
-        onError: (error: Error) => {
+        onError: (error: Error | AxiosError) => {
           if (
             error instanceof AxiosError &&
-            error.response?.data.statusCode === StatusCodes.NOT_ACCEPTABLE
+            error.response?.status === StatusCodes.NOT_ACCEPTABLE
           ) {
             // deep copy the error
             const newError = JSON.parse(JSON.stringify(error));
@@ -123,10 +123,25 @@ export default (queryConfig: QueryClientConfig) => {
           queryClient.resetQueries();
         },
         onError: (error: Error) => {
-          notifier?.({
-            type: signInWithPasswordRoutine.FAILURE,
-            payload: { error },
-          });
+          if (
+            error instanceof AxiosError &&
+            error.response?.status === StatusCodes.NOT_ACCEPTABLE
+          ) {
+            // deep copy the error
+            const newError = JSON.parse(JSON.stringify(error));
+            newError.message = FAILURE_MESSAGES.MEMBER_WITHOUT_PASSWORD;
+            notifier?.({
+              type: signInWithPasswordRoutine.FAILURE,
+              payload: {
+                error: newError,
+              },
+            });
+          } else {
+            notifier?.({
+              type: signInWithPasswordRoutine.FAILURE,
+              payload: { error },
+            });
+          }
         },
       },
     );


### PR DESCRIPTION
Ref https://github.com/graasp/graasp-auth/pull/183

After some discussion, this PR only fixes a bug in the test. 

The notifier should get the Graasp error message from the `error.response.data.message` to be able to translate them.