### PR TITLE
fix: use app id if key does not exist for requestApiAccessToken

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -14,14 +14,20 @@ export const getApps = async ({
   );
 
 export const requestApiAccessToken = async (
-  args: { id: UUID; key: string; origin: string },
+  args: {
+    id: UUID;
+    key: string;
+    origin: string;
+    /** @deprecated use key instead */
+    app?: string;
+  },
   { API_HOST }: Pick<QueryClientConfig, 'API_HOST'>,
 ): Promise<{ token: string }> => {
-  const { id, key, origin } = args;
+  const { id, key, origin, app } = args;
   return axios
     .post(`${API_HOST}/${buildGetApiAccessTokenRoute(id)}`, {
       origin,
-      key,
+      key: key ?? app,
     })
     .then(({ data }) => data);
 };


### PR DESCRIPTION
This PR handles back the app-id we used to use for apps. 
This allows twente apps to work again eg https://player.graasp.org/62915d32-ba68-476c-8602-5b4f6f21c32c

fix #416 