### PR TITLE
fix: use limit and offset

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -8,12 +8,14 @@ const axios = configureAxios();
 
 export type MeiliSearchProps = {
   limit?: number;
+  offset?: number;
   sort?: string[];
   attributesToCrop?: string[];
   cropLength?: number;
   highlightPreTag?: string;
   highlightPostTag?: string;
   page?: number;
+  elementsPerPage?: number;
 };
 
 /* eslint-disable import/prefer-default-export */
@@ -23,12 +25,12 @@ export const searchPublishedItems = async (
     categories,
     isPublishedRoot = true,
     limit,
+    offset,
     sort,
     attributesToCrop,
     cropLength,
     highlightPreTag,
     highlightPostTag,
-    page,
   }: {
     query?: string;
     categories?: Category['id'][][];
@@ -48,10 +50,10 @@ export const searchPublishedItems = async (
     cropLength,
     q,
     limit,
+    offset,
     sort,
     highlightPreTag,
     highlightPostTag,
-    page,
   };
 
   // handle filters

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -237,11 +237,12 @@ export const buildSearchPublishedItemsKey = (args: {
   categories?: Category['id'][][];
   isPublishedRoot?: boolean;
   limit?: number;
+  offset?: number;
   sort?: string[];
   highlightPreTag?: string;
   highlightPostTag?: string;
-  page: number;
-}) => [ITEMS_KEY, 'search', { isPublishedRoot: false, ...args }, args.page];
+  page?: number;
+}) => [ITEMS_KEY, 'search', { isPublishedRoot: false, ...args }];
 
 export const DATA_KEYS = {
   APPS_KEY,

--- a/src/hooks/search.test.ts
+++ b/src/hooks/search.test.ts
@@ -160,6 +160,7 @@ describe('Published Search Hook', () => {
           query,
           categories,
           isPublishedRoot,
+          page: 1,
         });
       const response = RESPONSE;
       const endpoints = [{ route, response, method: HttpMethod.POST }];

--- a/src/hooks/search.test.ts
+++ b/src/hooks/search.test.ts
@@ -94,6 +94,7 @@ const RESPONSE = {
 describe('Published Search Hook', () => {
   afterEach(() => {
     nock.cleanAll();
+    jest.clearAllMocks();
     queryClient.clear();
   });
 
@@ -179,8 +180,8 @@ describe('Published Search Hook', () => {
             attributesToCrop: undefined,
             highlightPostTag: undefined,
             highlightPreTag: undefined,
-            limit: undefined,
-            page: 1,
+            limit: 24,
+            offset: 0,
             sort: undefined,
           },
         ],
@@ -229,11 +230,11 @@ describe('Published Search Hook', () => {
             ],
             q: query,
             filter: 'categories IN [mycategoryid] AND isPublishedRoot = true',
-            page: 3,
+            limit: 24,
+            offset: 48, // (3 - 1) * 24
             attributesToCrop: undefined,
             highlightPostTag: undefined,
             highlightPreTag: undefined,
-            limit: undefined,
             sort: undefined,
           },
         ],

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -23,7 +23,9 @@ export default (queryConfig: QueryClientConfig) => {
       sort,
       highlightPreTag,
       highlightPostTag,
-      page = 1,
+      page,
+      limit,
+      offset,
       elementsPerPage = 24,
     }: {
       categories?: Category['id'][][];
@@ -42,24 +44,22 @@ export default (queryConfig: QueryClientConfig) => {
           highlightPostTag,
           page,
         }),
-        queryFn: (): Promise<MeiliSearchResultsRecord> => {
-          const offset = elementsPerPage * (page - 1);
-          return Api.searchPublishedItems(
+        queryFn: (): Promise<MeiliSearchResultsRecord> =>
+          Api.searchPublishedItems(
             {
               attributesToCrop,
               categories,
               cropLength,
               isPublishedRoot,
-              limit: elementsPerPage,
-              offset,
+              limit: page ? elementsPerPage : limit,
+              offset: page ? elementsPerPage * (page - 1) : offset,
               query: debouncedQuery,
               sort,
               highlightPreTag,
               highlightPostTag,
             },
             queryConfig,
-          ).then((data) => convertJs(data));
-        },
+          ).then((data) => convertJs(data)),
         // we could add data in success, but not sure the data will be consistent with GET /item
         enabled,
         ...defaultQueryOptions,

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -19,12 +19,12 @@ export default (queryConfig: QueryClientConfig) => {
       cropLength,
       enabled = true,
       isPublishedRoot = true,
-      limit,
       query,
       sort,
       highlightPreTag,
       highlightPostTag,
       page = 1,
+      elementsPerPage = 24,
     }: {
       categories?: Category['id'][][];
       enabled?: boolean;
@@ -37,28 +37,29 @@ export default (queryConfig: QueryClientConfig) => {
           query: debouncedQuery,
           categories,
           isPublishedRoot,
-          limit,
           sort,
           highlightPreTag,
           highlightPostTag,
           page,
         }),
-        queryFn: (): Promise<MeiliSearchResultsRecord> =>
-          Api.searchPublishedItems(
+        queryFn: (): Promise<MeiliSearchResultsRecord> => {
+          const offset = elementsPerPage * (page - 1);
+          return Api.searchPublishedItems(
             {
               attributesToCrop,
               categories,
               cropLength,
               isPublishedRoot,
-              limit,
+              limit: elementsPerPage,
+              offset,
               query: debouncedQuery,
               sort,
               highlightPreTag,
               highlightPostTag,
-              page,
             },
             queryConfig,
-          ).then((data) => convertJs(data)),
+          ).then((data) => convertJs(data));
+        },
         // we could add data in success, but not sure the data will be consistent with GET /item
         enabled,
         ...defaultQueryOptions,


### PR DESCRIPTION
This PR changes the pagination mechanism to use the `limit` and `offset` strategies instead of the `page` and `histPerPage` strategy.

If `page` is set, then `limit` and `offset` are computed from `page` and `elementsPerPage` as such:
`limit = elementsPerPage`
`offset = elementsPerPage * (page - 1)` since page is 1-indexed

If `page` is not set, then `limit` and `offset` are used as is (falling back to default values if undefined). 