### PR TITLE
fix(type): use correct type for transformed date

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -1,4 +1,4 @@
-import { Action, ActionData, UUID } from '@graasp/sdk';
+import { Action, ActionData, AggregateBy, UUID } from '@graasp/sdk';
 
 import { PartialQueryConfigForApi } from '../types';
 import { AggregateActionsArgs } from '../utils/action';
@@ -17,14 +17,12 @@ export const getActions = async (
     .get<ActionData>(`${API_HOST}/${buildGetActions(args.itemId, args)}`)
     .then(({ data }) => data);
 
-export const getAggregateActions = async (
-  args: AggregateActionsArgs,
+export const getAggregateActions = async <K extends AggregateBy[]>(
+  args: AggregateActionsArgs<K>,
   { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
-    .get<{ aggregateResult: number; createdDay: Date }[]>(
-      `${API_HOST}/${buildGetAggregateActions(args)}`,
-    )
+    .get(`${API_HOST}/${buildGetAggregateActions(args)}`)
     .then(({ data }) => data);
 
 export const exportActions = async (

--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -22,7 +22,7 @@ export const getAggregateActions = async (
   { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
-    .get<{ aggregateResult: number; createdDay: string }[]>(
+    .get<{ aggregateResult: number; createdDay: Date }[]>(
       `${API_HOST}/${buildGetAggregateActions(args)}`,
     )
     .then(({ data }) => data);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,4 +1,10 @@
-import { DiscriminatedItem, ItemTag, ItemTagType, UUID } from '@graasp/sdk';
+import {
+  AggregateBy,
+  DiscriminatedItem,
+  ItemTag,
+  ItemTagType,
+  UUID,
+} from '@graasp/sdk';
 
 import qs from 'qs';
 
@@ -295,7 +301,9 @@ export const buildGetActions = (
       addQueryPrefix: true,
     },
   )}`;
-export const buildGetAggregateActions = (args: AggregateActionsArgs) =>
+export const buildGetAggregateActions = <K extends AggregateBy[]>(
+  args: AggregateActionsArgs<K>,
+) =>
   `${ITEMS_ROUTE}/${args.itemId}/actions/aggregation${qs.stringify(
     {
       requestedSampleSize: args.requestedSampleSize,

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -1,4 +1,4 @@
-import { Category, UUID } from '@graasp/sdk';
+import { AggregateBy, Category, UUID } from '@graasp/sdk';
 
 import { AggregateActionsArgs } from '../utils/action';
 import { hashItemsIds } from '../utils/item';
@@ -202,10 +202,10 @@ export const buildActionsKey = (args: {
   },
 ];
 
-export const buildAggregateActionsKey = (
-  args: Omit<AggregateActionsArgs, 'itemId'> &
-    Partial<Pick<AggregateActionsArgs, 'itemId'>>,
-) => ['aggregateActions', args];
+export const buildAggregateActionsKey = <K extends AggregateBy[]>(
+  itemId: string | undefined,
+  args: Omit<AggregateActionsArgs<K>, 'itemId'>,
+) => ['aggregateActions', itemId, args];
 
 export const buildInvitationKey = (id?: UUID) => ['invitations', id];
 export const buildItemInvitationsKey = (id?: UUID) => [

--- a/src/hooks/action.test.ts
+++ b/src/hooks/action.test.ts
@@ -113,7 +113,6 @@ describe('Action Hooks', () => {
 
   describe('useAggregateActions', () => {
     const args = {
-      itemId,
       view: Context.Builder,
       requestedSampleSize: 5,
       type: ['update'],
@@ -122,12 +121,12 @@ describe('Action Hooks', () => {
       aggregateMetric: AggregateMetric.ActionCount,
       aggregateBy: [AggregateBy.CreatedDay],
     };
-    const route = `/${buildGetAggregateActions(args)}`;
-    const key = buildAggregateActionsKey(args);
+    const route = `/${buildGetAggregateActions({ itemId, ...args })}`;
+    const key = buildAggregateActionsKey(itemId, args);
     const response = AGGREGATE_ACTIONS_DATA;
 
     it(`Receive aggregate actions for item id`, async () => {
-      const hook = () => hooks.useAggregateActions(args);
+      const hook = () => hooks.useAggregateActions(itemId, args);
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
       expect(data?.toJS()).toEqual(response);
@@ -138,7 +137,7 @@ describe('Action Hooks', () => {
       ).toEqual(response);
     });
     it(`Receive aggregate actions for item id`, async () => {
-      const hook = () => hooks.useAggregateActions(args);
+      const hook = () => hooks.useAggregateActions(itemId, args);
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
       expect(data?.toJS()).toEqual(response);
@@ -150,7 +149,7 @@ describe('Action Hooks', () => {
     });
 
     it(`Unauthorized`, async () => {
-      const hook = () => hooks.useAggregateActions(args);
+      const hook = () => hooks.useAggregateActions(itemId, args);
       const endpoints = [
         {
           route,

--- a/src/hooks/action.ts
+++ b/src/hooks/action.ts
@@ -57,7 +57,7 @@ export default (queryConfig: QueryClientConfig) => {
     return useQuery({
       queryKey: buildAggregateActionsKey(args),
       queryFn: (): Promise<
-        ImmutableCast<{ aggregateResult: number; createdDay: string }[]>
+        ImmutableCast<{ aggregateResult: number; createdDay: Date }[]>
       > => {
         const { itemId } = args;
         if (!itemId) {

--- a/src/hooks/action.ts
+++ b/src/hooks/action.ts
@@ -7,7 +7,7 @@ import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
 import { buildActionsKey, buildAggregateActionsKey } from '../config/keys';
 import { QueryClientConfig } from '../types';
-import { AggregateActionsArgs } from '../utils/action';
+import { AggregateActionsArgs, MappedAggregateBy } from '../utils/action';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;
@@ -45,28 +45,31 @@ export default (queryConfig: QueryClientConfig) => {
     });
   };
 
-  const useAggregateActions = (
-    args: Omit<AggregateActionsArgs, 'itemId'> &
-      Partial<Pick<AggregateActionsArgs, 'itemId'>>,
+  const useAggregateActions = <T extends (keyof MappedAggregateBy)[]>(
+    itemId: string | undefined,
+    args: Omit<AggregateActionsArgs<T>, 'itemId'>,
     options?: { enabled?: boolean },
   ) => {
     const enabledValue =
       (options?.enabled ?? true) &&
-      Boolean(args.itemId) &&
+      Boolean(itemId) &&
       Boolean(args.requestedSampleSize);
     return useQuery({
-      queryKey: buildAggregateActionsKey(args),
+      queryKey: buildAggregateActionsKey(itemId, args),
       queryFn: (): Promise<
-        ImmutableCast<{ aggregateResult: number; createdDay: Date }[]>
+        ImmutableCast<
+          ({ aggregateResult: number } & {
+            // this adds a key for each element in the aggregation array and sets it to the relevant type
+            [Key in T[number]]: MappedAggregateBy[Key];
+          })[]
+        >
       > => {
-        const { itemId } = args;
         if (!itemId) {
           throw new UndefinedArgument();
         }
-        return Api.getAggregateActions(
-          args as AggregateActionsArgs,
-          queryConfig,
-        ).then((data) => convertJs(data));
+        return Api.getAggregateActions({ itemId, ...args }, queryConfig).then(
+          (data) => convertJs(data),
+        );
       },
       ...defaultQueryOptions,
       enabled: enabledValue,

--- a/src/utils/action.ts
+++ b/src/utils/action.ts
@@ -7,7 +7,7 @@ import {
   Item,
 } from '@graasp/sdk';
 
-export type AggregateActionsArgs = {
+export type AggregateActionsArgs<K extends AggregateBy[]> = {
   itemId: Item['id'];
   view: Context;
   requestedSampleSize: number;
@@ -15,5 +15,17 @@ export type AggregateActionsArgs = {
   countGroupBy: CountGroupBy[];
   aggregateFunction: AggregateFunction;
   aggregateMetric: AggregateMetric;
-  aggregateBy: AggregateBy[];
+  aggregateBy: K;
+};
+
+export type MappedAggregateBy = {
+  [AggregateBy.CreatedDay]: Date;
+  // todo: this should maybe be returned by the backend as a number directly ?
+  [AggregateBy.CreatedDayOfWeek]: string;
+  // todo: same as above, this should be returned as a number by the backend
+  [AggregateBy.CreatedTimeOfDay]: string;
+  [AggregateBy.ItemId]: string;
+  [AggregateBy.ActionType]: string;
+  [AggregateBy.ActionCount]: number;
+  [AggregateBy.ActionLocation]: string;
 };

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -647,9 +647,9 @@ export const ACTIONS_DATA: ActionData = createMockActionData({
 });
 
 export const AGGREGATE_ACTIONS_DATA = [
-  { aggregateResult: 1.5, createdDay: '01-01-2023' },
-  { aggregateResult: 2, createdDay: '02-01-2023' },
-  { aggregateResult: 4, createdDay: '03-01-2023' },
+  { aggregateResult: 1.5, createdDay: new Date('2023-10-10T00:00:00.000Z') },
+  { aggregateResult: 2, createdDay: new Date('2023-07-10T00:00:00.000Z') },
+  { aggregateResult: 4, createdDay: new Date('2023-11-10T00:00:00.000Z') },
 ];
 
 export const buildInvitation = (values: Partial<Invitation>): Invitation => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,7 +2949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^2.0.11, @smithy/config-resolver@npm:^2.0.15":
+"@smithy/config-resolver@npm:^2.0.11":
   version: 2.0.15
   resolution: "@smithy/config-resolver@npm:2.0.15"
   dependencies:
@@ -2962,7 +2962,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "@smithy/config-resolver@npm:2.0.14"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/types": ^2.3.5
+    "@smithy/util-config-provider": ^2.0.0
+    "@smithy/util-middleware": ^2.0.4
+    tslib: ^2.5.0
+  checksum: 5fa08a715e20b49db178b22806d79cb43756b7f720007abb018ccf975270529869153ea25b98b99da3ffc80607c19a65ceb147fe908e80301eb51288802ea7b7
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^2.0.0":
+  version: 2.0.12
+  resolution: "@smithy/credential-provider-imds@npm:2.0.12"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/property-provider": ^2.0.12
+    "@smithy/types": ^2.3.5
+    "@smithy/url-parser": ^2.0.11
+    tslib: ^2.5.0
+  checksum: baccd59a625c04d9fb9114f471c527c108b17ccdd04ff079029e4337948a60129bdb1f5306727b4b6df777522f3890e6a0f4b8b6521ed472ed2a425547bd4747
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^2.0.16":
   version: 2.0.16
   resolution: "@smithy/credential-provider-imds@npm:2.0.16"
   dependencies:
@@ -2972,19 +2998,6 @@ __metadata:
     "@smithy/url-parser": ^2.0.11
     tslib: ^2.5.0
   checksum: 1079f9b59d60f460bfbc95c722a740664733b5d6c219ff8ac04d85d8af78eccabc71ed08d39cf11ec1e80203e3b65e08eb06a99524c358b2a959e2baa4787fd4
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^2.0.17":
-  version: 2.0.17
-  resolution: "@smithy/credential-provider-imds@npm:2.0.17"
-  dependencies:
-    "@smithy/node-config-provider": ^2.1.2
-    "@smithy/property-provider": ^2.0.12
-    "@smithy/types": ^2.3.5
-    "@smithy/url-parser": ^2.0.11
-    tslib: ^2.5.0
-  checksum: 726a2161cfe7c23491b778a1c62861838dc705f59b93a5feb0f414994fd15daf1fee9114618750e2cc6044d3223939eb16755c65c54efb99062729d2ded60d57
   languageName: node
   linkType: hard
 
@@ -3133,25 +3146,24 @@ __metadata:
   linkType: hard
 
 "@smithy/middleware-endpoint@npm:^2.0.10":
-  version: 2.1.2
-  resolution: "@smithy/middleware-endpoint@npm:2.1.2"
+  version: 2.1.0
+  resolution: "@smithy/middleware-endpoint@npm:2.1.0"
   dependencies:
     "@smithy/middleware-serde": ^2.0.11
-    "@smithy/node-config-provider": ^2.1.2
-    "@smithy/shared-ini-file-loader": ^2.2.1
+    "@smithy/node-config-provider": ^2.1.1
     "@smithy/types": ^2.3.5
     "@smithy/url-parser": ^2.0.11
     "@smithy/util-middleware": ^2.0.4
     tslib: ^2.5.0
-  checksum: e55349f25feeb16f23ef5873c3d3ba9f062dbadf82ffdbc3ceb5b1bb19f9a6901a0ef665cae935fffd9f33b50d9c0f52f8a6a1a74eee6d3a131149a75faa492b
+  checksum: d4b5cb0dc10de50d5f2865bf93e25476d8c6b01aa31980fe5d64084f4092d4bc0578940ae7ae81e1f002ad4106599af594ac165f45141355b861cbc087dfb6b0
   languageName: node
   linkType: hard
 
 "@smithy/middleware-retry@npm:^2.0.13":
-  version: 2.0.17
-  resolution: "@smithy/middleware-retry@npm:2.0.17"
+  version: 2.0.16
+  resolution: "@smithy/middleware-retry@npm:2.0.16"
   dependencies:
-    "@smithy/node-config-provider": ^2.1.2
+    "@smithy/node-config-provider": ^2.1.1
     "@smithy/protocol-http": ^3.0.7
     "@smithy/service-error-classification": ^2.0.4
     "@smithy/types": ^2.3.5
@@ -3159,7 +3171,7 @@ __metadata:
     "@smithy/util-retry": ^2.0.4
     tslib: ^2.5.0
     uuid: ^8.3.2
-  checksum: 3035a9a3d6532d3aa3014671956e4896f2cc5888f88496f1a7907d3b050a403f1bfcaf25ed2a82d5c97fdfbb44bef549a05e5841156043d42ab952a9f12f6bdd
+  checksum: 9348bf7663ad85469614bda8a672bc8a5a104137caf1f3eb77553462f52044d27b933be177f850abe202fb9b4e060f39982e85565d8caf164de6377ffba82272
   languageName: node
   linkType: hard
 
@@ -3399,17 +3411,17 @@ __metadata:
   linkType: hard
 
 "@smithy/util-defaults-mode-node@npm:^2.0.15":
-  version: 2.0.20
-  resolution: "@smithy/util-defaults-mode-node@npm:2.0.20"
+  version: 2.0.19
+  resolution: "@smithy/util-defaults-mode-node@npm:2.0.19"
   dependencies:
-    "@smithy/config-resolver": ^2.0.15
-    "@smithy/credential-provider-imds": ^2.0.17
-    "@smithy/node-config-provider": ^2.1.2
+    "@smithy/config-resolver": ^2.0.14
+    "@smithy/credential-provider-imds": ^2.0.16
+    "@smithy/node-config-provider": ^2.1.1
     "@smithy/property-provider": ^2.0.12
     "@smithy/smithy-client": ^2.1.11
     "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 76055f1f759feecc9419242d30bbd94e0a2fee658c909b90bc7fb5cb19adc844221e21021ffc0aab5d98dc0070ce7f1d950c196d14c56d3c1ed2c5e4fcf7f0c2
+  checksum: 86609e2ea7673b3e735e25ca4647dbd70a65fc335af860617936299443c2dd1e2d9481bc7d3b172cf589a4fbc8f12040cf219345ece80fe3dab331d6a52f8168
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes incorrect types in the hooks.

### Explanation
The API returns the `createdAtDay` as a ISOString representation of a date. 
We have an interceptor for axios that automatically applies a transform to convert dates formatted in strings to `Date` objects. So the correct type that the consumer will see in this case is `Date`.