### PR TITLE
refactor: use common axios instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "commonjs",
   "repository": "graasp/graasp-query-client",
   "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "author": "Graasp",

--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -1,8 +1,7 @@
 import { Action, ActionData, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
+import { PartialQueryConfigForApi } from '../types';
 import { AggregateActionsArgs } from '../utils/action';
-import configureAxios from './axios';
 import {
   buildExportActions,
   buildGetActions,
@@ -10,11 +9,9 @@ import {
   buildPostItemAction,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getActions = async (
   args: { itemId: UUID; requestedSampleSize: number; view: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get<ActionData>(`${API_HOST}/${buildGetActions(args.itemId, args)}`)
@@ -22,7 +19,7 @@ export const getActions = async (
 
 export const getAggregateActions = async (
   args: AggregateActionsArgs,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get<{ aggregateResult: number; createdDay: string }[]>(
@@ -32,13 +29,13 @@ export const getAggregateActions = async (
 
 export const exportActions = async (
   args: { itemId: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   axios.post(`${API_HOST}/${buildExportActions(args.itemId)}`);
 
 export const postItemAction = async (
   itemId: UUID,
   payload: { type: string; extra?: { [key: string]: unknown } },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Action> =>
   axios.post(`${API_HOST}/${buildPostItemAction(itemId)}`, payload);

--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -1,14 +1,13 @@
 import { App, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import { buildAppListRoute, buildGetApiAccessTokenRoute } from './routes';
-
-const axios = configureAxios();
 
 export const getApps = async ({
   API_HOST,
-}: Pick<QueryClientConfig, 'API_HOST'>): Promise<App[]> =>
+  axios,
+}: PartialQueryConfigForApi): Promise<App[]> =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${buildAppListRoute}`).then(({ data }) => data),
   );
@@ -21,7 +20,7 @@ export const requestApiAccessToken = async (
     /** @deprecated use key instead */
     app?: string;
   },
-  { API_HOST }: Pick<QueryClientConfig, 'API_HOST'>,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<{ token: string }> => {
   const { id, key, origin, app } = args;
   return axios

--- a/src/api/authentication.ts
+++ b/src/api/authentication.ts
@@ -1,8 +1,8 @@
 import { HttpMethod } from '@graasp/sdk';
 import { Password } from '@graasp/sdk/frontend';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   MOBILE_SIGN_IN_ROUTE,
   MOBILE_SIGN_IN_WITH_PASSWORD_ROUTE,
@@ -13,26 +13,27 @@ import {
   SIGN_UP_ROUTE,
 } from './routes';
 
-const axios = configureAxios();
-
-export const signOut = ({ API_HOST }: QueryClientConfig): Promise<void> =>
+export const signOut = ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi): Promise<void> =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${SIGN_OUT_ROUTE}`).then(({ data }) => data),
   );
 
 export const signIn = async (
   payload: { email: string; captcha: string; url?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> => axios.post(`${API_HOST}/${SIGN_IN_ROUTE}`, payload);
 
 export const mobileSignIn = async (
   payload: { email: string; challenge: string; captcha: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> => axios.post(`${API_HOST}/${MOBILE_SIGN_IN_ROUTE}`, payload);
 
 export const signInWithPassword = async (
   payload: { email: string; password: Password; captcha: string; url?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<{ resource: string }> =>
   axios({
     method: HttpMethod.POST,
@@ -49,7 +50,7 @@ export const mobileSignInWithPassword = async (
     challenge: string;
     captcha: string;
   },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<{ resource: string }> =>
   axios
     .post(`${API_HOST}/${MOBILE_SIGN_IN_WITH_PASSWORD_ROUTE}`, payload, {
@@ -60,10 +61,10 @@ export const mobileSignInWithPassword = async (
 
 export const signUp = async (
   payload: { name: string; email: string; captcha: string; url?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> => axios.post(`${API_HOST}/${SIGN_UP_ROUTE}`, payload);
 
 export const mobileSignUp = async (
   payload: { name: string; email: string; challenge: string; captcha: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> => axios.post(`${API_HOST}/${MOBILE_SIGN_UP_ROUTE}`, payload);

--- a/src/api/category.ts
+++ b/src/api/category.ts
@@ -1,7 +1,7 @@
 import { Category, CategoryType, ItemCategory, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   GET_CATEGORY_TYPES_ROUTE,
   buildDeleteItemCategoryRoute,
@@ -12,15 +12,14 @@ import {
   buildPostItemCategoryRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getCategoryTypes = async ({
   API_HOST,
-}: QueryClientConfig): Promise<CategoryType[]> =>
+  axios,
+}: PartialQueryConfigForApi): Promise<CategoryType[]> =>
   axios.get(`${API_HOST}/${GET_CATEGORY_TYPES_ROUTE}`).then(({ data }) => data);
 
 export const getCategories = async (
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
   typeIds?: UUID[],
 ): Promise<Category[]> =>
   axios
@@ -29,7 +28,7 @@ export const getCategories = async (
 
 export const getCategory = async (
   categoryId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Category> =>
   axios
     .get(`${API_HOST}/${buildGetCategoryRoute(categoryId)}`)
@@ -37,7 +36,7 @@ export const getCategory = async (
 
 export const getItemCategories = async (
   itemId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemCategory[]> =>
   axios
     .get(`${API_HOST}/${buildGetItemCategoriesRoute(itemId)}`)
@@ -45,7 +44,7 @@ export const getItemCategories = async (
 
 export const buildGetItemsForCategoriesRoute = async (
   categoryIds: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildGetItemsInCategoryRoute(categoryIds)}`)
@@ -54,7 +53,7 @@ export const buildGetItemsForCategoriesRoute = async (
 // payload: itemId, categoryId
 export const postItemCategory = async (
   { itemId, categoryId }: { itemId: UUID; categoryId: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemCategory> =>
   verifyAuthentication(() =>
     axios
@@ -66,7 +65,7 @@ export const postItemCategory = async (
 
 export const deleteItemCategory = async (
   args: { itemCategoryId: UUID; itemId: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemCategory> =>
   verifyAuthentication(() =>
     axios

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -7,8 +7,8 @@ import {
   UUID,
 } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildClearItemChatRoute,
   buildDeleteItemChatMessageRoute,
@@ -18,11 +18,9 @@ import {
   buildPostItemChatMessageRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getItemChat = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ChatMessage[]> =>
   axios
     .get(`${API_HOST}/${buildGetItemChatRoute(id)}`)
@@ -30,7 +28,7 @@ export const getItemChat = async (
 
 export const exportItemChat = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(
     (): Promise<ExportedChatMessage> =>
@@ -41,7 +39,7 @@ export const exportItemChat = async (
 
 export const postItemChatMessage = async (
   { itemId, body, mentions }: PostChatMessageParamType,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(
     (): Promise<ChatMessage> =>
@@ -55,7 +53,7 @@ export const postItemChatMessage = async (
 
 export const patchItemChatMessage = async (
   { itemId, messageId, body, mentions }: PatchChatMessageParamType,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(
     (): Promise<ChatMessage> =>
@@ -72,7 +70,7 @@ export const patchItemChatMessage = async (
 
 export const deleteItemChatMessage = async (
   { itemId, messageId }: DeleteChatMessageParamType,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(
     (): Promise<ChatMessage> =>
@@ -85,7 +83,7 @@ export const deleteItemChatMessage = async (
 
 export const clearItemChat = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() =>
     axios

--- a/src/api/invitation.ts
+++ b/src/api/invitation.ts
@@ -1,8 +1,8 @@
 import { Invitation, ResultOf, UUID } from '@graasp/sdk';
 import { NewInvitation } from '@graasp/sdk/frontend';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildDeleteInvitationRoute,
   buildGetInvitationRoute,
@@ -12,11 +12,9 @@ import {
   buildResendInvitationRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 // eslint-disable-next-line import/prefer-default-export
 export const getInvitation = async (
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
   id: UUID,
 ) =>
   axios
@@ -25,7 +23,7 @@ export const getInvitation = async (
 
 export const postInvitations = async (
   { itemId, invitations }: { itemId: UUID; invitations: NewInvitation[] },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ResultOf<Invitation>> =>
   verifyAuthentication(() =>
     axios
@@ -35,7 +33,7 @@ export const postInvitations = async (
 
 export const getInvitationsForItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Invitation[]> =>
   verifyAuthentication(() =>
     axios
@@ -46,7 +44,7 @@ export const getInvitationsForItem = async (
 export const patchInvitation = async (
   payload: { itemId: UUID; id: UUID },
   body: Partial<Invitation>,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Invitation> =>
   verifyAuthentication(() =>
     axios
@@ -56,7 +54,7 @@ export const patchInvitation = async (
 
 export const deleteInvitation = async (
   payload: { itemId: UUID; id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Invitation> =>
   verifyAuthentication(() =>
     axios
@@ -66,7 +64,7 @@ export const deleteInvitation = async (
 
 export const resendInvitation = async (
   payload: { itemId: UUID; id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() =>
     axios.post(`${API_HOST}/${buildResendInvitationRoute(payload)}`),

--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -1,9 +1,9 @@
 import { DiscriminatedItem, Item, ResultOf, UUID } from '@graasp/sdk';
 
 import { DEFAULT_THUMBNAIL_SIZE } from '../config/constants';
-import { QueryClientConfig } from '../types';
+import { PartialQueryConfigForApi } from '../types';
 import { getParentsIdsFromPath } from '../utils/item';
-import configureAxios, { verifyAuthentication } from './axios';
+import { verifyAuthentication } from './axios';
 import {
   GET_OWN_ITEMS_ROUTE,
   GET_RECYCLED_ITEMS_DATA_ROUTE,
@@ -24,18 +24,21 @@ import {
   buildRestoreItemsRoute,
 } from './routes';
 
-const axios = configureAxios();
-
-export const getItem = (id: UUID, { API_HOST }: QueryClientConfig) =>
-  axios.get(`${API_HOST}/${buildGetItemRoute(id)}`).then(({ data }) => data);
+export const getItem = (
+  id: UUID,
+  { API_HOST, axios }: PartialQueryConfigForApi,
+) => axios.get(`${API_HOST}/${buildGetItemRoute(id)}`).then(({ data }) => data);
 
 export const getItems = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ResultOf<Item>> =>
   axios.get(`${API_HOST}/${buildGetItemsRoute(ids)}`).then(({ data }) => data);
 
-export const getOwnItems = async ({ API_HOST }: QueryClientConfig) =>
+export const getOwnItems = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_OWN_ITEMS_ROUTE}`).then(({ data }) => data),
   );
@@ -48,7 +51,7 @@ export type PostItemPayloadType = Partial<DiscriminatedItem> &
 // querystring = {parentId}
 export const postItem = async (
   { name, type, description, extra, parentId }: PostItemPayloadType,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<DiscriminatedItem> =>
   verifyAuthentication(() =>
     axios
@@ -63,7 +66,7 @@ export const postItem = async (
 
 export const deleteItems = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() =>
     axios
@@ -76,7 +79,7 @@ export const deleteItems = async (
 export const editItem = async (
   id: UUID,
   item: Partial<Item>,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<DiscriminatedItem> =>
   verifyAuthentication(() =>
     axios
@@ -91,7 +94,7 @@ export const getChildren = async (
   id: UUID,
   // eslint-disable-next-line default-param-last
   ordered = true,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildGetChildrenRoute(id, ordered)}`)
@@ -99,7 +102,7 @@ export const getChildren = async (
 
 export const getParents = async (
   { id, path }: { id: UUID; path?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> => {
   // shortcut to prevent fetching parents if path shows that item is a root
   if (path) {
@@ -115,7 +118,7 @@ export const getParents = async (
 
 export const getDescendants = async (
   { id }: { id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> =>
   axios
     .get(`${API_HOST}/${buildGetItemDescendants(id)}`)
@@ -129,7 +132,7 @@ export const moveItems = async (
     ids: UUID[];
     to?: UUID;
   },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() => {
     // send parentId if defined
@@ -149,7 +152,7 @@ export const copyItems = async (
     ids: UUID[];
     to?: UUID;
   },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() => {
     // send parentId if defined
@@ -159,7 +162,10 @@ export const copyItems = async (
     });
   });
 
-export const getSharedItems = async ({ API_HOST }: QueryClientConfig) =>
+export const getSharedItems = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios
       .get<Item[]>(`${API_HOST}/${SHARED_ITEM_WITH_ROUTE}`, {})
@@ -168,7 +174,7 @@ export const getSharedItems = async ({ API_HOST }: QueryClientConfig) =>
 
 export const getFileContent = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildDownloadFilesRoute(id)}`, {
@@ -178,7 +184,7 @@ export const getFileContent = async (
 
 export const getFileContentUrl = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildDownloadFilesRoute(id)}`, {
@@ -188,7 +194,10 @@ export const getFileContentUrl = async (
     })
     .then(({ data }) => data);
 
-export const getRecycledItemsData = async ({ API_HOST }: QueryClientConfig) =>
+export const getRecycledItemsData = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios
       .get<Item[]>(`${API_HOST}/${GET_RECYCLED_ITEMS_DATA_ROUTE}`)
@@ -197,7 +206,7 @@ export const getRecycledItemsData = async ({ API_HOST }: QueryClientConfig) =>
 
 export const recycleItems = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -207,7 +216,7 @@ export const recycleItems = async (
 
 export const restoreItems = async (
   itemIds: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -217,7 +226,7 @@ export const restoreItems = async (
 
 export const downloadItemThumbnail = async (
   { id, size = DEFAULT_THUMBNAIL_SIZE }: { id: UUID; size?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(
@@ -234,7 +243,7 @@ export const downloadItemThumbnail = async (
 
 export const downloadItemThumbnailUrl = async (
   { id, size = DEFAULT_THUMBNAIL_SIZE }: { id: UUID; size?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(

--- a/src/api/itemExport.ts
+++ b/src/api/itemExport.ts
@@ -1,15 +1,12 @@
 import { UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios from './axios';
+import { PartialQueryConfigForApi } from '../types';
 import { buildExportItemRoute } from './routes';
-
-const axios = configureAxios();
 
 /* eslint-disable import/prefer-default-export */
 export const exportItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Blob> =>
   // options?: { public: boolean },
   axios({

--- a/src/api/itemFavorite.ts
+++ b/src/api/itemFavorite.ts
@@ -1,14 +1,13 @@
 import { Item, ItemFavorite, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import { GET_FAVORITE_ITEMS_ROUTE, buildFavoriteItemRoute } from './routes';
-
-const axios = configureAxios();
 
 export const getFavoriteItems = async ({
   API_HOST,
-}: QueryClientConfig): Promise<Item[]> =>
+  axios,
+}: PartialQueryConfigForApi): Promise<Item[]> =>
   verifyAuthentication(() =>
     axios
       .get(`${API_HOST}/${GET_FAVORITE_ITEMS_ROUTE}`)
@@ -17,7 +16,7 @@ export const getFavoriteItems = async ({
 
 export const addFavoriteItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemFavorite> =>
   verifyAuthentication(() =>
     axios
@@ -27,7 +26,7 @@ export const addFavoriteItem = async (
 
 export const removeFavoriteItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<UUID> =>
   verifyAuthentication(() =>
     axios

--- a/src/api/itemFlag.ts
+++ b/src/api/itemFlag.ts
@@ -1,12 +1,10 @@
 import { ItemFlag, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import { GET_FLAGS_ROUTE, buildPostItemFlagRoute } from './routes';
 
-const axios = configureAxios();
-
-export const getFlags = async ({ API_HOST }: QueryClientConfig) =>
+export const getFlags = async ({ API_HOST, axios }: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_FLAGS_ROUTE}`).then(({ data }) => data),
   );
@@ -14,7 +12,7 @@ export const getFlags = async ({ API_HOST }: QueryClientConfig) =>
 // payload: flagId, itemId
 export const postItemFlag = async (
   { type, itemId }: { type: UUID; itemId: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemFlag> =>
   axios
     .post(`${API_HOST}/${buildPostItemFlagRoute(itemId)}`, {

--- a/src/api/itemLike.ts
+++ b/src/api/itemLike.ts
@@ -1,7 +1,7 @@
 import { UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildDeleteItemLikeRoute,
   buildGetItemLikesRoute,
@@ -9,11 +9,9 @@ import {
   buildPostItemLikeRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getLikedItems = async (
   memberId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -21,14 +19,17 @@ export const getLikedItems = async (
       .then(({ data }) => data),
   );
 
-export const getItemLikes = async (id: UUID, { API_HOST }: QueryClientConfig) =>
+export const getItemLikes = async (
+  id: UUID,
+  { API_HOST, axios }: PartialQueryConfigForApi,
+) =>
   axios
     .get(`${API_HOST}/${buildGetItemLikesRoute(id)}`)
     .then(({ data }) => data);
 
 export const postItemLike = async (
   itemId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -38,7 +39,7 @@ export const postItemLike = async (
 
 export const deleteItemLike = async (
   itemId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios

--- a/src/api/itemLogin.ts
+++ b/src/api/itemLogin.ts
@@ -5,8 +5,8 @@ import {
   UUID,
 } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildDeleteItemLoginSchemaRoute, // buildGetItemLoginRoute,
   buildGetItemLoginSchemaRoute,
@@ -15,8 +15,6 @@ import {
   buildPutItemLoginSchemaRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const postItemLoginSignIn = async (
   {
     itemId,
@@ -24,7 +22,7 @@ export const postItemLoginSignIn = async (
     memberId,
     password,
   }: { itemId: UUID; username?: string; memberId?: UUID; password?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Member> =>
   axios
     .post(`${API_HOST}/${buildPostItemLoginSignInRoute(itemId)}`, {
@@ -36,7 +34,7 @@ export const postItemLoginSignIn = async (
 
 export const getItemLoginSchema = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildGetItemLoginSchemaRoute(id)}`)
@@ -44,7 +42,7 @@ export const getItemLoginSchema = async (
 
 export const getItemLoginSchemaType = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemLoginSchemaType> =>
   axios
     .get(`${API_HOST}/${buildGetItemLoginSchemaTypeRoute(id)}`)
@@ -52,7 +50,7 @@ export const getItemLoginSchemaType = async (
 
 export const putItemLoginSchema = async (
   { itemId, type }: { itemId: UUID; type: ItemLoginSchemaType },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemLoginSchema> =>
   verifyAuthentication(() =>
     axios
@@ -64,7 +62,7 @@ export const putItemLoginSchema = async (
 
 export const deleteItemLoginSchema = async (
   { itemId }: { itemId: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() =>
     axios.delete(`${API_HOST}/${buildDeleteItemLoginSchemaRoute(itemId)}`),

--- a/src/api/itemPublish.ts
+++ b/src/api/itemPublish.ts
@@ -1,7 +1,7 @@
 import { Item, ItemPublished, ResultOf, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildGetAllPublishedItemsRoute,
   buildGetItemPublishedInformationRoute,
@@ -13,11 +13,9 @@ import {
   buildManyGetItemPublishedInformationsRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getAllPublishedItems = async (
   args: { categoryIds?: UUID[] },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> =>
   axios
     .get(`${API_HOST}/${buildGetAllPublishedItemsRoute(args?.categoryIds)}`)
@@ -25,7 +23,7 @@ export const getAllPublishedItems = async (
 
 export const getMostLikedPublishedItems = async (
   args: { limit?: number },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> =>
   axios
     .get(`${API_HOST}/${buildGetMostLikedPublishedItemsRoute(args?.limit)}`)
@@ -33,7 +31,7 @@ export const getMostLikedPublishedItems = async (
 
 export const getMostRecentPublishedItems = async (
   args: { limit?: number },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> =>
   axios
     .get(`${API_HOST}/${buildGetMostRecentPublishedItemsRoute(args?.limit)}`)
@@ -41,7 +39,7 @@ export const getMostRecentPublishedItems = async (
 
 export const getPublishedItemsForMember = async (
   memberId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Item[]> =>
   axios
     .get(`${API_HOST}/${buildGetPublishedItemsForMemberRoute(memberId)}`)
@@ -49,7 +47,7 @@ export const getPublishedItemsForMember = async (
 
 export const getItemPublishedInformation = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildGetItemPublishedInformationRoute(id)}`)
@@ -57,7 +55,7 @@ export const getItemPublishedInformation = async (
 
 export const getManyItemPublishedInformations = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ResultOf<ItemPublished>> =>
   axios
     .get(`${API_HOST}/${buildManyGetItemPublishedInformationsRoute(ids)}`)
@@ -65,7 +63,7 @@ export const getManyItemPublishedInformations = async (
 
 export const publishItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
   notification?: boolean,
 ): Promise<ItemPublished> =>
   verifyAuthentication(() =>
@@ -76,7 +74,7 @@ export const publishItem = async (
 
 export const unpublishItem = async (
   id: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemPublished> =>
   verifyAuthentication(() =>
     axios

--- a/src/api/itemTag.ts
+++ b/src/api/itemTag.ts
@@ -1,7 +1,7 @@
 import { ItemTagType, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   GET_TAGS_ROUTE,
   buildDeleteItemTagRoute,
@@ -10,19 +10,20 @@ import {
   buildPostItemTagRoute,
 } from './routes';
 
-const axios = configureAxios();
-
-export const getTags = async ({ API_HOST }: QueryClientConfig) =>
+export const getTags = async ({ API_HOST, axios }: PartialQueryConfigForApi) =>
   axios.get(`${API_HOST}/${GET_TAGS_ROUTE}`).then(({ data }) => data);
 
-export const getItemTags = async (id: UUID, { API_HOST }: QueryClientConfig) =>
+export const getItemTags = async (
+  id: UUID,
+  { API_HOST, axios }: PartialQueryConfigForApi,
+) =>
   axios
     .get(`${API_HOST}/${buildGetItemTagsRoute(id)}`)
     .then(({ data }) => data);
 
 export const getItemsTags = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get(`${API_HOST}/${buildGetItemsTagsRoute(ids)}`)
@@ -31,7 +32,7 @@ export const getItemsTags = async (
 // payload: tagId, itemPath, creator
 export const postItemTag = async (
   { itemId, type }: { itemId: UUID; type: ItemTagType },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -41,7 +42,7 @@ export const postItemTag = async (
 
 export const deleteItemTag = async (
   { itemId, type }: { itemId: UUID; type: `${ItemTagType}` | ItemTagType },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios

--- a/src/api/itemValidation.ts
+++ b/src/api/itemValidation.ts
@@ -1,7 +1,7 @@
 import { UUID } from '@graasp/sdk';
 
 import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { verifyAuthentication } from './axios';
 import {
   GET_ITEM_VALIDATION_REVIEWS_ROUTE,
   GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE,
@@ -13,10 +13,9 @@ import {
   buildUpdateItemValidationReviewRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getItemValidationReviews = async ({
   API_HOST,
+  axios,
 }: QueryClientConfig) =>
   axios
     .get(`${API_HOST}/${GET_ITEM_VALIDATION_REVIEWS_ROUTE}`)
@@ -24,6 +23,7 @@ export const getItemValidationReviews = async ({
 
 export const getItemValidationStatuses = async ({
   API_HOST,
+  axios,
 }: QueryClientConfig) =>
   axios
     .get(`${API_HOST}/${GET_ITEM_VALIDATION_STATUSES_ROUTE}`)
@@ -31,13 +31,14 @@ export const getItemValidationStatuses = async ({
 
 export const getItemValidationReviewStatuses = async ({
   API_HOST,
+  axios,
 }: QueryClientConfig) =>
   axios
     .get(`${API_HOST}/${GET_ITEM_VALIDATION_REVIEW_STATUSES_ROUTE}`)
     .then(({ data }) => data);
 
 export const getLastItemValidationGroup = async (
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
   itemId: UUID,
 ) =>
   verifyAuthentication(() =>
@@ -46,7 +47,7 @@ export const getLastItemValidationGroup = async (
       .then(({ data }) => data),
   );
 export const getItemValidationAndReview = async (
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
   itemId: UUID,
 ) =>
   verifyAuthentication(() =>
@@ -56,7 +57,7 @@ export const getItemValidationAndReview = async (
   );
 
 export const getItemValidationGroups = async (
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
   iVId: UUID,
 ) =>
   verifyAuthentication(() =>
@@ -67,7 +68,7 @@ export const getItemValidationGroups = async (
 
 export const postItemValidation = async (
   { itemId }: { itemId: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -78,7 +79,7 @@ export const postItemValidation = async (
 // payload: status, reason ("" if not provided)
 export const updateItemValidationReview = async (
   { id, status, reason }: { id: UUID; status: string; reason?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
 ) =>
   verifyAuthentication(() =>
     axios

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -4,8 +4,8 @@ import { Password } from '@graasp/sdk/frontend';
 import { StatusCodes } from 'http-status-codes';
 
 import { DEFAULT_THUMBNAIL_SIZE, SIGNED_OUT_USER } from '../config/constants';
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   GET_CURRENT_MEMBER_ROUTE,
   buildDeleteMemberRoute,
@@ -19,11 +19,9 @@ import {
   buildUploadAvatarRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getMembersBy = async (
   { emails }: { emails: string[] },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ResultOf<Member>> =>
   axios
     .get(`${API_HOST}/${buildGetMembersBy(emails)}`)
@@ -31,18 +29,21 @@ export const getMembersBy = async (
 
 export const getMember = async (
   { id }: { id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) => axios.get(`${API_HOST}/${buildGetMember(id)}`).then(({ data }) => data);
 
 export const getMembers = (
   { ids }: { ids: UUID[] },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   axios
     .get<ResultOf<Member[]>>(`${API_HOST}/${buildGetMembersRoute(ids)}`)
     .then(({ data }) => data);
 
-export const getCurrentMember = async ({ API_HOST }: QueryClientConfig) =>
+export const getCurrentMember = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios
       .get(`${API_HOST}/${GET_CURRENT_MEMBER_ROUTE}`)
@@ -59,7 +60,10 @@ export const getCurrentMember = async ({ API_HOST }: QueryClientConfig) =>
       }),
   );
 
-export const getMemberStorage = async ({ API_HOST }: QueryClientConfig) =>
+export const getMemberStorage = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios
       .get(`${API_HOST}/${buildGetMemberStorage()}`)
@@ -68,7 +72,7 @@ export const getMemberStorage = async ({ API_HOST }: QueryClientConfig) =>
 
 export const editMember = async (
   payload: { id: UUID; extra?: MemberExtra; name?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Member> =>
   verifyAuthentication(() =>
     axios
@@ -80,7 +84,7 @@ export const editMember = async (
 
 export const deleteMember = async (
   { id }: { id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -90,7 +94,7 @@ export const deleteMember = async (
 
 export const updatePassword = async (
   payload: { password: Password; currentPassword: Password },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<void> =>
   verifyAuthentication(() =>
     axios
@@ -106,7 +110,7 @@ export const uploadAvatar = async (
     filename,
     contentType,
   }: { itemId: UUID; filename: string; contentType: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -124,7 +128,7 @@ export const uploadAvatar = async (
 
 export const downloadAvatar = async (
   { id, size = DEFAULT_THUMBNAIL_SIZE }: { id: UUID; size?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<Blob> =>
   axios
     .get(
@@ -137,7 +141,7 @@ export const downloadAvatar = async (
 
 export const downloadAvatarUrl = async (
   { id, size = DEFAULT_THUMBNAIL_SIZE }: { id: UUID; size?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<string> =>
   axios
     .get(

--- a/src/api/membership.ts
+++ b/src/api/membership.ts
@@ -1,8 +1,8 @@
 import { ItemMembership, PermissionLevel, ResultOf, UUID } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import { getMembersBy } from './member';
 import {
   buildDeleteItemMembershipRoute,
@@ -12,11 +12,9 @@ import {
   buildPostManyItemMembershipsRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getMembershipsForItems = async (
   ids: UUID[],
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ResultOf<ItemMembership[]>> =>
   axios
     .get(`${API_HOST}/${buildGetItemMembershipsForItemsRoute(ids)}`)
@@ -27,18 +25,15 @@ export const postManyItemMemberships = async (
     memberships,
     itemId,
   }: { itemId: UUID; memberships: Partial<ItemMembership>[] },
-  config: QueryClientConfig,
-): Promise<ResultOf<ItemMembership>> => {
-  const { API_HOST } = config;
-
-  return verifyAuthentication(() =>
+  { API_HOST, axios }: PartialQueryConfigForApi,
+): Promise<ResultOf<ItemMembership>> =>
+  verifyAuthentication(() =>
     axios
       .post(`${API_HOST}/${buildPostManyItemMembershipsRoute(itemId)}`, {
         memberships,
       })
       .then(({ data }) => data),
   );
-};
 
 export const postItemMembership = async (
   {
@@ -46,9 +41,9 @@ export const postItemMembership = async (
     email,
     permission,
   }: { id: UUID; email: string; permission: PermissionLevel },
-  config: QueryClientConfig,
+  config: PartialQueryConfigForApi,
 ): Promise<ItemMembership> => {
-  const { API_HOST } = config;
+  const { API_HOST, axios } = config;
   const member = await getMembersBy({ emails: [email] }, config);
 
   if (!member || !Object.values(member.data).length) {
@@ -68,7 +63,7 @@ export const postItemMembership = async (
 
 export const editItemMembership = async (
   { id, permission }: { id: UUID; permission: PermissionLevel },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemMembership> =>
   verifyAuthentication(() =>
     axios
@@ -80,7 +75,7 @@ export const editItemMembership = async (
 
 export const deleteItemMembership = async (
   { id }: { id: UUID },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<ItemMembership> =>
   verifyAuthentication(() =>
     axios

--- a/src/api/mentions.ts
+++ b/src/api/mentions.ts
@@ -1,7 +1,7 @@
 import { ChatMention, UUID } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi, QueryClientConfig } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   buildClearMentionsRoute,
   buildDeleteMentionRoute,
@@ -9,10 +9,9 @@ import {
   buildPatchMentionRoute,
 } from './routes';
 
-const axios = configureAxios();
-
 export const getMemberMentions = async ({
   API_HOST,
+  axios,
 }: QueryClientConfig): Promise<ChatMention[]> =>
   verifyAuthentication(() =>
     axios
@@ -22,7 +21,7 @@ export const getMemberMentions = async ({
 
 export const patchMemberMentionsStatus = async (
   { id: mentionId, status }: { id: UUID; status: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
 ): Promise<ChatMention> =>
   verifyAuthentication(
     (): Promise<ChatMention> =>
@@ -35,7 +34,7 @@ export const patchMemberMentionsStatus = async (
 
 export const deleteMention = async (
   mentionId: UUID,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: QueryClientConfig,
 ): Promise<ChatMention> =>
   verifyAuthentication(() =>
     axios
@@ -45,7 +44,8 @@ export const deleteMention = async (
 
 export const clearMentions = async ({
   API_HOST,
-}: QueryClientConfig): Promise<ChatMention[]> =>
+  axios,
+}: PartialQueryConfigForApi): Promise<ChatMention[]> =>
   verifyAuthentication(() =>
     axios
       .delete(`${API_HOST}/${buildClearMentionsRoute()}`)

--- a/src/api/search.test.ts
+++ b/src/api/search.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { QueryClientConfig } from '../types';
+import configureAxios from './axios';
 import { searchPublishedItems } from './search';
 
 type SearchQuery = { queries: { q: string; filter: string }[] };
@@ -8,6 +8,8 @@ type SearchQuery = { queries: { q: string; filter: string }[] };
 describe('Search API', () => {
   describe('searchPublishedItems', () => {
     let spy: jest.SpyInstance;
+    const axiosInstance = configureAxios();
+
     beforeEach(() => {
       spy = jest.spyOn(axios, 'post').mockImplementation(async () => true);
     });
@@ -20,9 +22,13 @@ describe('Search API', () => {
       const query = 'query';
       const categories = [['id1']];
 
-      await searchPublishedItems({ query, categories }, {
-        API_HOST: 'apihost',
-      } as QueryClientConfig);
+      await searchPublishedItems(
+        { query, categories },
+        {
+          API_HOST: 'apihost',
+          axios: axiosInstance,
+        },
+      );
 
       const call = (spy.mock.calls[0][1] as SearchQuery).queries[0];
       expect(call.q).toEqual(query);
@@ -33,9 +39,13 @@ describe('Search API', () => {
     it('correctly send request without query string', async () => {
       const categories = [['id1']];
 
-      await searchPublishedItems({ categories }, {
-        API_HOST: 'apihost',
-      } as QueryClientConfig);
+      await searchPublishedItems(
+        { categories },
+        {
+          API_HOST: 'apihost',
+          axios: axiosInstance,
+        },
+      );
 
       const call = (spy.mock.calls[0][1] as SearchQuery).queries[0];
       expect(call.q).toBeUndefined();
@@ -46,9 +56,13 @@ describe('Search API', () => {
     it('correctly send request without categories', async () => {
       const query = 'query';
 
-      await searchPublishedItems({ query }, {
-        API_HOST: 'apihost',
-      } as QueryClientConfig);
+      await searchPublishedItems(
+        { query },
+        {
+          API_HOST: 'apihost',
+          axios: axiosInstance,
+        },
+      );
 
       const call = (spy.mock.calls[0][1] as SearchQuery).queries[0];
       expect(call.q).toEqual(query);
@@ -57,9 +71,13 @@ describe('Search API', () => {
     it('correctly send request without categories and publishedRoot false', async () => {
       const query = 'query';
 
-      await searchPublishedItems({ query, isPublishedRoot: false }, {
-        API_HOST: 'apihost',
-      } as QueryClientConfig);
+      await searchPublishedItems(
+        { query, isPublishedRoot: false },
+        {
+          API_HOST: 'apihost',
+          axios: axiosInstance,
+        },
+      );
 
       const call = (spy.mock.calls[0][1] as SearchQuery).queries[0];
       expect(call.q).toEqual(query);
@@ -69,9 +87,13 @@ describe('Search API', () => {
       const query = 'query';
       const categories = [['id1', 'id2'], ['id3', 'id4'], ['id5']];
 
-      await searchPublishedItems({ query, categories }, {
-        API_HOST: 'apihost',
-      } as QueryClientConfig);
+      await searchPublishedItems(
+        { query, categories },
+        {
+          API_HOST: 'apihost',
+          axios: axiosInstance,
+        },
+      );
 
       const call = (spy.mock.calls[0][1] as SearchQuery).queries[0];
       expect(call.q).toEqual(query);

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,10 +1,7 @@
 import { Category, DiscriminatedItem, INDEX_NAME } from '@graasp/sdk';
 
-import { QueryClientConfig } from '../types';
-import configureAxios from './axios';
+import { PartialQueryConfigForApi } from '../types';
 import { SEARCH_PUBLISHED_ITEMS_ROUTE } from './routes';
-
-const axios = configureAxios();
 
 export type MeiliSearchProps = {
   limit?: number;
@@ -36,7 +33,7 @@ export const searchPublishedItems = async (
     categories?: Category['id'][][];
     isPublishedRoot?: boolean;
   } & MeiliSearchProps,
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ): Promise<DiscriminatedItem[]> => {
   const query: {
     indexUid: string;

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -1,5 +1,5 @@
-import { QueryClientConfig } from '../types';
-import configureAxios, { verifyAuthentication } from './axios';
+import { PartialQueryConfigForApi } from '../types';
+import { verifyAuthentication } from './axios';
 import {
   CREATE_SETUP_INTENT_ROUTE,
   GET_CARDS_ROUTE,
@@ -11,10 +11,9 @@ import {
   buildSetDefaultCardRoute,
 } from './routes';
 
-const axios = configureAxios();
 export const getPlan = async (
   { planId }: { planId: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -22,12 +21,15 @@ export const getPlan = async (
       .then(({ data }) => data),
   );
 
-export const getPlans = async ({ API_HOST }: QueryClientConfig) =>
+export const getPlans = async ({ API_HOST, axios }: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_PLANS_ROUTE}`).then(({ data }) => data),
   );
 
-export const getOwnPlan = async ({ API_HOST }: QueryClientConfig) =>
+export const getOwnPlan = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_OWN_PLAN_ROUTE}`).then(({ data }) => data),
   );
@@ -35,7 +37,7 @@ export const getOwnPlan = async ({ API_HOST }: QueryClientConfig) =>
 // payload: planId
 export const changePlan = async (
   { planId, cardId }: { planId: string; cardId?: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -43,14 +45,14 @@ export const changePlan = async (
       .then(({ data }) => data),
   );
 
-export const getCards = async ({ API_HOST }: QueryClientConfig) =>
+export const getCards = async ({ API_HOST, axios }: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_CARDS_ROUTE}`).then(({ data }) => data),
   );
 
 export const setDefaultCard = async (
   { cardId }: { cardId: string },
-  { API_HOST }: QueryClientConfig,
+  { API_HOST, axios }: PartialQueryConfigForApi,
 ) =>
   verifyAuthentication(() =>
     axios
@@ -58,14 +60,20 @@ export const setDefaultCard = async (
       .then(({ data }) => data),
   );
 
-export const createSetupIntent = async ({ API_HOST }: QueryClientConfig) =>
+export const createSetupIntent = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios
       .post(`${API_HOST}/${CREATE_SETUP_INTENT_ROUTE}`)
       .then(({ data }) => data),
   );
 
-export const getCurrentCustomer = async ({ API_HOST }: QueryClientConfig) =>
+export const getCurrentCustomer = async ({
+  API_HOST,
+  axios,
+}: PartialQueryConfigForApi) =>
   verifyAuthentication(() =>
     axios.get(`${API_HOST}/${GET_CURRENT_CUSTOMER}`).then(({ data }) => data),
   );

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -12,6 +12,7 @@ import {
 } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 
+import configureAxios from './api/axios';
 import {
   CACHE_TIME_MILLISECONDS,
   STALE_TIME_MILLISECONDS,
@@ -54,9 +55,15 @@ export default (config: Partial<QueryClientConfig>) => {
     DOMAIN: config.DOMAIN ?? getHostname(),
   };
 
+  const axios = configureAxios();
+
+  // apply in place changes on axios
+  config.onConfigAxios?.(axios);
+
   // define config for query client
   const queryConfig: QueryClientConfig = {
     ...baseConfig,
+    axios,
     // derive WS_HOST from API_HOST if needed
     WS_HOST:
       config?.WS_HOST || `${baseConfig.API_HOST.replace('http', 'ws')}/ws`,
@@ -101,5 +108,6 @@ export default (config: Partial<QueryClientConfig>) => {
     dehydrate,
     Hydrate,
     mutations,
+    axios,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { QueryObserverOptions } from 'react-query';
 
 import { isDataEqual } from './utils/util';
@@ -19,6 +19,8 @@ export type QueryClientConfig = {
   DOMAIN?: string;
   enableWebsocket: boolean;
   notifier?: Notifier;
+  axios: AxiosInstance;
+  onConfigAxios?: (axios: AxiosInstance) => void;
   defaultQueryOptions: {
     // time until data in cache considered stale if cache not invalidated
     staleTime: number;
@@ -35,3 +37,8 @@ export type QueryClientConfig = {
     isDataEqual?: typeof isDataEqual;
   };
 };
+
+export type PartialQueryConfigForApi = Pick<
+  QueryClientConfig,
+  'API_HOST' | 'axios'
+>;

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -10,6 +10,7 @@ import {
   UseMutationResult,
 } from 'react-query';
 
+import configureAxios from '../src/api/axios';
 import configureHooks from '../src/hooks';
 import configureQueryClient from '../src/queryClient';
 import { Notifier, QueryClientConfig } from '../src/types';
@@ -28,6 +29,7 @@ export const setUpTest = (args?: Args) => {
   const queryConfig: QueryClientConfig = {
     API_HOST,
     DOMAIN,
+    axios: configureAxios(),
     defaultQueryOptions: {
       retry: 0,
       cacheTime: 0,

--- a/test/wsUtils.tsx
+++ b/test/wsUtils.tsx
@@ -4,6 +4,7 @@ import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { QueryClient } from 'react-query';
 
+import configureAxios from '../src/api/axios';
 import configureQueryClient from '../src/queryClient';
 import { Notifier, QueryClientConfig } from '../src/types';
 import { isDataEqual } from '../src/utils/util';
@@ -33,9 +34,11 @@ export const setUpWsTest = (args?: {
       // do nothing
     },
   } = args ?? {};
+  const axios = configureAxios();
   const queryConfig: QueryClientConfig = {
     API_HOST,
     DOMAIN,
+    axios,
     defaultQueryOptions: {
       retry: 0,
       cacheTime: 0,


### PR DESCRIPTION
I've refactored the api files to use the same axios instance. 
Eventually this will help define interceptors externally (like needed for mobile)

close #489 