### PR TITLE
fix: allow union litterals in aggregate

### DIFF
--- a/src/utils/action.ts
+++ b/src/utils/action.ts
@@ -9,7 +9,7 @@ import {
 
 export type AggregateActionsArgs<K extends AggregateBy[]> = {
   itemId: Item['id'];
-  view: Context;
+  view: `${Context}` | Context;
   requestedSampleSize: number;
   type?: string[];
   countGroupBy: CountGroupBy[];


### PR DESCRIPTION
In this PR I update the type of the `useAggregateAction` to support using string literals instead of named `Context` enum only (it is still possible to use `Context` enum but not mandatory.
This allows us to use a subset of `Context` in analytics for example. See the linked PR: https://github.com/graasp/graasp-analytics/pull/264 