### PR TITLE
fix: better understanding of `staleTime` and `cacheTime` 

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 
 // React Query Configs
 
-// duration for which query data is considered "fresh", meaning all access to that entry will be from cached data, no refetch.
+// duration for which query data is considered "fresh", meaning every access to that entry will be from cached data, no refetch.
 export const STALE_TIME_MILLISECONDS = 3 * 1000; // default is 3 seconds to deduplicate calls to the same resource on load.
 // time during which to keep the cache entry of a query that is not on screen.
 // increasing this time allows to keep data between screens for example.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,12 +4,12 @@ import { StatusCodes } from 'http-status-codes';
 
 // React Query Configs
 
-// time during which cache entry is never refetched
-export const STALE_TIME_MILLISECONDS = 0; // default is 0 to always refetch, can increase to trade load against consistency
-// time during which cache entry is still served while refetches are pending
+// duration for which query data is considered "fresh", meaning all access to that entry will be from cached data, no refetch.
+export const STALE_TIME_MILLISECONDS = 3 * 1000; // default is 3 seconds to deduplicate calls to the same resource on load.
+// time during which to keep the cache entry of a query that is not on screen.
+// increasing this time allows to keep data between screens for example.
 export const CACHE_TIME_MILLISECONDS = 1000 * 60 * 5; // default is 5 min
-export const CONSTANT_KEY_CACHE_TIME_MILLISECONDS = 1000 * 60 * 15; // default is 15 min
-export const STALE_TIME_CHILDREN_PAGINATED_MILLISECONDS = 1000000000000; // very long time since it is updated from useEffect hook
+export const CONSTANT_KEY_STALE_TIME_MILLISECONDS = 1000 * 60 * 15; // default is 15 min
 
 export const FALLBACK_TO_PUBLIC_FOR_STATUS_CODES = [
   StatusCodes.UNAUTHORIZED,

--- a/src/hooks/apps.ts
+++ b/src/hooks/apps.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 
 import * as Api from '../api';
-import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
+import { CONSTANT_KEY_STALE_TIME_MILLISECONDS } from '../config/constants';
 import { APPS_KEY } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
@@ -14,7 +14,7 @@ export default (queryConfig: QueryClientConfig) => {
         queryKey: APPS_KEY,
         queryFn: () => Api.getApps(queryConfig),
         ...defaultQueryOptions,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       }),
   };
 };

--- a/src/hooks/category.ts
+++ b/src/hooks/category.ts
@@ -3,7 +3,7 @@ import { UUID } from '@graasp/sdk';
 import { useQuery } from 'react-query';
 
 import * as Api from '../api';
-import { CONSTANT_KEY_CACHE_TIME_MILLISECONDS } from '../config/constants';
+import { CONSTANT_KEY_STALE_TIME_MILLISECONDS } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
   buildCategoriesKey,
@@ -22,7 +22,7 @@ export default (queryConfig: QueryClientConfig) => {
       queryKey: buildCategoriesKey(typeIds),
       queryFn: () => Api.getCategories(queryConfig, typeIds),
       ...defaultQueryOptions,
-      cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+      staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
     });
 
   const useCategory = (categoryId: UUID) =>
@@ -30,7 +30,7 @@ export default (queryConfig: QueryClientConfig) => {
       queryKey: buildCategoryKey(categoryId),
       queryFn: () => Api.getCategory(categoryId, queryConfig),
       ...defaultQueryOptions,
-      cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+      staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
     });
 
   const useItemCategories = (itemId?: UUID) =>

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -20,10 +20,9 @@ import * as Api from '../api';
 import { splitRequestByIdsAndReturn } from '../api/axios';
 import { ItemSearchParams } from '../api/routes';
 import {
-  CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+  CONSTANT_KEY_STALE_TIME_MILLISECONDS,
   DEFAULT_THUMBNAIL_SIZE,
   PAGINATED_ITEMS_PER_PAGE,
-  STALE_TIME_CHILDREN_PAGINATED_MILLISECONDS,
 } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
 import {
@@ -185,7 +184,6 @@ export default (
 
       const childrenPaginatedOptions = {
         ...defaultQueryOptions,
-        staleTime: STALE_TIME_CHILDREN_PAGINATED_MILLISECONDS,
       };
 
       return useInfiniteQuery(
@@ -372,7 +370,7 @@ export default (
         },
         enabled: Boolean(id) && enabled,
         ...defaultQueryOptions,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       }),
 
     useFileContentUrl: (
@@ -389,7 +387,7 @@ export default (
         },
         enabled: Boolean(id) && enabled,
         ...defaultQueryOptions,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       }),
 
     useRecycledItems: (options?: { getUpdates?: boolean }) => {
@@ -454,6 +452,7 @@ export default (
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       });
     },
 
@@ -482,6 +481,7 @@ export default (
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       });
     },
 

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -454,7 +454,6 @@ export default (
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
       });
     },
 
@@ -483,7 +482,6 @@ export default (
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
       });
     },
 

--- a/src/hooks/member.ts
+++ b/src/hooks/member.ts
@@ -10,7 +10,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import * as Api from '../api';
 import { splitRequestByIdsAndReturn } from '../api/axios';
 import {
-  CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+  CONSTANT_KEY_STALE_TIME_MILLISECONDS,
   DEFAULT_THUMBNAIL_SIZE,
 } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
@@ -104,7 +104,7 @@ export default (queryConfig: QueryClientConfig) => {
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       });
     },
 
@@ -138,7 +138,7 @@ export default (queryConfig: QueryClientConfig) => {
         },
         ...defaultQueryOptions,
         enabled: Boolean(id) && shouldFetch,
-        cacheTime: CONSTANT_KEY_CACHE_TIME_MILLISECONDS,
+        staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
       });
     },
 

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -4,7 +4,6 @@ import {
   ItemType,
   MAX_TARGETS_FOR_MODIFY_REQUEST,
   RecycledItemData,
-  ThumbnailSize,
   UUID,
 } from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
@@ -21,7 +20,6 @@ import {
   RECYCLED_ITEMS_DATA_KEY,
   buildItemChildrenKey,
   buildItemKey,
-  buildItemThumbnailKey,
   getKeyForParentId,
   itemsWithGeolocationKeys,
 } from '../config/keys';
@@ -493,12 +491,6 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { id }) => {
-          Object.values(ThumbnailSize).forEach((size) => {
-            const key1 = buildItemThumbnailKey({ replyUrl: false, id, size });
-            queryClient.invalidateQueries(key1);
-            const key2 = buildItemThumbnailKey({ replyUrl: true, id, size });
-            queryClient.invalidateQueries(key2);
-          });
           // invalidate item to update settings.hasThumbnail
           queryClient.invalidateQueries(buildItemKey(id));
         },


### PR DESCRIPTION
Reading the docs more carefully, there was a miss-understanding in the use of `staleTime` and `cacheTime`.

<img width="1728" alt="React Query staleTime and cacheTime" src="https://github.com/graasp/graasp-query-client/assets/39373170/63ccb9b8-9066-49e7-ab8e-c11aa4eebe99">


So for our application we want:
- a `staleTime` that represents our usual loading time, or until all components have rendered on screen and we would like to minimise the number of duplicated request to the backend. Ideally only one per resource.
- a `cacheTime` that is big enough so that when navigating between pages we can display the "old" data before updating it -> this will remove a lot of loading spinners once we have data (even if it is slightly older).

Proposed default values:
- `staleTime`: 3 seconds
- `cacheTime`: 5 minutes (this is the default for react query)

Understanding this difference we should change `Constant cache time` to actually be a `Constant stale time` for rarely updated data (thumbnails, app list, and others)