### PR TITLE
feat: add types filter in useAccessible

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3,9 +3,11 @@ import {
   DiscriminatedItem,
   ItemTag,
   ItemTagType,
+  ItemType,
   Member,
   PermissionLevel,
   UUID,
+  UnionOfConst,
 } from '@graasp/sdk';
 
 import qs from 'qs';
@@ -43,6 +45,7 @@ export type ItemSearchParams =
         | 'item.created_at'
         | 'item.updated_at';
       permissions?: PermissionLevel[];
+      types?: UnionOfConst<typeof ItemType>[];
     }
   | undefined;
 export const buildGetAccessibleItems = (

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -361,7 +361,7 @@ describe('Items Hooks', () => {
     it(`Route constrcuted correctly for accessible folders`, async () => {
       const typesParams = { types: [ItemType.FOLDER] };
       const url = `/${buildGetAccessibleItems(typesParams, {})}`;
-      const urlObject = new URL(url, 'http://fake-url.tmp');
+      const urlObject = new URL(url, 'https://no-existing-url.tmp');
       const queryParams = urlObject.searchParams;
       const typesValue = queryParams.get('types');
 

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -358,6 +358,16 @@ describe('Items Hooks', () => {
       expect(queryClient.getQueryData(key)).toMatchObject(response);
     });
 
+    it(`Route constrcuted correctly for accessible folders`, async () => {
+      const typesParams = { types: [ItemType.FOLDER] };
+      const url = `/${buildGetAccessibleItems(typesParams, {})}`;
+      const urlObject = new URL(url, 'http://fake-url.tmp');
+      const queryParams = urlObject.searchParams;
+      const typesValue = queryParams.get('types');
+
+      expect(typesValue).toEqual(ItemType.FOLDER);
+    });
+
     it(`Unauthorized`, async () => {
       const endpoints = [
         {


### PR DESCRIPTION
This PR refers to (graasp/graasp#787):
- Allow to filter the accessible items by an array of types.
- Another PR (#606) is created to do the same with the children.
  - The backend already support that in graasp/graasp#787.
  - It is in another PR, because we have to update the UI to use new version of `useChildren`.