### PR TITLE
refactor: change item keys

### DIFF
--- a/src/hooks/category.test.ts
+++ b/src/hooks/category.test.ts
@@ -14,12 +14,7 @@ import {
   buildGetItemCategoriesRoute,
   buildGetItemsInCategoryRoute,
 } from '../api/routes';
-import {
-  buildCategoriesKey,
-  buildCategoryKey,
-  buildItemCategoriesKey,
-  buildItemsByCategoriesKey,
-} from '../config/keys';
+import { categoryKeys, itemKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -69,7 +64,7 @@ describe('Category Hooks', () => {
   describe('useCategories', () => {
     const typeIds = ['type-id1', 'type-id2'];
     const route = `/${buildGetCategoriesRoute(typeIds)}`;
-    const key = buildCategoriesKey(typeIds);
+    const key = categoryKeys.many(typeIds);
 
     const hook = () => hooks.useCategories(typeIds);
 
@@ -107,7 +102,7 @@ describe('Category Hooks', () => {
   describe('useCategory', () => {
     const categoryId = 'id';
     const route = `/${buildGetCategoryRoute(categoryId)}`;
-    const key = buildCategoryKey(categoryId);
+    const key = categoryKeys.single(categoryId);
 
     const hook = () => hooks.useCategory(categoryId);
 
@@ -145,7 +140,7 @@ describe('Category Hooks', () => {
   describe('useItemCategories', () => {
     const itemId = 'item-id';
     const route = `/${buildGetItemCategoriesRoute(itemId)}`;
-    const key = buildItemCategoriesKey(itemId);
+    const key = itemKeys.single(itemId).categories;
 
     const hook = () => hooks.useItemCategories(itemId);
 
@@ -184,7 +179,7 @@ describe('Category Hooks', () => {
   describe('useItemsInCategories', () => {
     const categoryIds = ['id1'];
     const route = `/${buildGetItemsInCategoryRoute(categoryIds)}`;
-    const key = buildItemsByCategoriesKey(categoryIds);
+    const key = itemKeys.categories(categoryIds);
 
     const hook = () => hooks.useItemsInCategories(categoryIds);
 

--- a/src/hooks/category.ts
+++ b/src/hooks/category.ts
@@ -5,12 +5,7 @@ import { useQuery } from 'react-query';
 import * as Api from '../api';
 import { CONSTANT_KEY_STALE_TIME_MILLISECONDS } from '../config/constants';
 import { UndefinedArgument } from '../config/errors';
-import {
-  buildCategoriesKey,
-  buildCategoryKey,
-  buildItemCategoriesKey,
-  buildItemsByCategoriesKey,
-} from '../config/keys';
+import { categoryKeys, itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -19,7 +14,7 @@ export default (queryConfig: QueryClientConfig) => {
   // get categories
   const useCategories = (typeIds?: UUID[]) =>
     useQuery({
-      queryKey: buildCategoriesKey(typeIds),
+      queryKey: categoryKeys.many(typeIds),
       queryFn: () => Api.getCategories(queryConfig, typeIds),
       ...defaultQueryOptions,
       staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
@@ -27,7 +22,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useCategory = (categoryId: UUID) =>
     useQuery({
-      queryKey: buildCategoryKey(categoryId),
+      queryKey: categoryKeys.single(categoryId),
       queryFn: () => Api.getCategory(categoryId, queryConfig),
       ...defaultQueryOptions,
       staleTime: CONSTANT_KEY_STALE_TIME_MILLISECONDS,
@@ -35,7 +30,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useItemCategories = (itemId?: UUID) =>
     useQuery({
-      queryKey: buildItemCategoriesKey(itemId),
+      queryKey: itemKeys.single(itemId).categories,
       queryFn: () => {
         if (!itemId) {
           throw new UndefinedArgument();
@@ -48,7 +43,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useItemsInCategories = (categoryIds: UUID[]) =>
     useQuery({
-      queryKey: buildItemsByCategoriesKey(categoryIds),
+      queryKey: itemKeys.categories(categoryIds),
       queryFn: () =>
         Api.buildGetItemsForCategoriesRoute(categoryIds, queryConfig),
       ...defaultQueryOptions,

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -36,17 +36,7 @@ import {
   buildGetItemRoute,
   buildGetItemsRoute,
 } from '../api/routes';
-import {
-  OWN_ITEMS_KEY,
-  SHARED_ITEMS_KEY,
-  accessibleItemsKeys,
-  buildFileContentKey,
-  buildItemChildrenKey,
-  buildItemKey,
-  buildItemParentsKey,
-  buildItemThumbnailKey,
-  buildItemsKey,
-} from '../config/keys';
+import { OWN_ITEMS_KEY, itemKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -76,7 +66,9 @@ describe('Items Hooks', () => {
         queryClient.getQueryData<DiscriminatedItem[]>(OWN_ITEMS_KEY),
       ).toEqual(response);
       for (const item of response) {
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toEqual(item);
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toEqual(item);
       }
     });
 
@@ -106,7 +98,7 @@ describe('Items Hooks', () => {
     const params = { ordered: true };
     const route = `/${buildGetChildrenRoute(id, params)}`;
     const response = generateFolders();
-    const key = buildItemChildrenKey(id);
+    const key = itemKeys.single(id).children();
 
     it(`Receive children of item by id`, async () => {
       const hook = () => hooks.useChildren(id);
@@ -122,7 +114,9 @@ describe('Items Hooks', () => {
       // verify cache keys
       expect(queryClient.getQueryData(key)).toEqual(response);
       for (const item of response) {
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toEqual(item);
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toEqual(item);
       }
     });
 
@@ -151,7 +145,9 @@ describe('Items Hooks', () => {
       // verify cache keys
       expect(queryClient.getQueryData(key)).toBeFalsy();
       for (const item of response) {
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toBeFalsy();
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toBeFalsy();
       }
     });
 
@@ -170,7 +166,9 @@ describe('Items Hooks', () => {
       // verify cache keys
       expect(queryClient.getQueryData(key)).toBeFalsy();
       for (const item of response) {
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toBeFalsy();
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toBeFalsy();
       }
     });
 
@@ -191,9 +189,9 @@ describe('Items Hooks', () => {
       // verify cache keys
       expect(queryClient.getQueryData(key)).toMatchObject(response);
       for (const item of response) {
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toMatchObject(
-          item,
-        );
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toMatchObject(item);
       }
     });
 
@@ -214,7 +212,9 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildItemChildrenKey(id))).toBeFalsy();
+      expect(
+        queryClient.getQueryData(itemKeys.single(id).children()),
+      ).toBeFalsy();
     });
   });
 
@@ -239,10 +239,12 @@ describe('Items Hooks', () => {
       expect(data).toMatchObject(response);
       // verify cache keys
       expect(
-        queryClient.getQueryData(buildItemParentsKey(childItem.id)),
+        queryClient.getQueryData(itemKeys.single(childItem.id).parents),
       ).toMatchObject(response);
       for (const i of response) {
-        expect(queryClient.getQueryData(buildItemKey(i.id))).toMatchObject(i);
+        expect(
+          queryClient.getQueryData(itemKeys.single(i.id).content),
+        ).toMatchObject(i);
       }
     });
 
@@ -264,11 +266,13 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isFetched).toBeFalsy();
       expect(
-        queryClient.getQueryData(buildItemParentsKey(childItem.id)),
+        queryClient.getQueryData(itemKeys.single(childItem.id).parents),
       ).toBeFalsy();
       // verify cache keys
       for (const i of response) {
-        expect(queryClient.getQueryData(buildItemKey(i.id))).toBeFalsy();
+        expect(
+          queryClient.getQueryData(itemKeys.single(i.id).content),
+        ).toBeFalsy();
       }
     });
 
@@ -282,7 +286,7 @@ describe('Items Hooks', () => {
       expect(data).toHaveLength(0);
       expect(isFetched).toBeTruthy();
       expect(
-        queryClient.getQueryData(buildItemParentsKey(childItem.id)),
+        queryClient.getQueryData(itemKeys.single(childItem.id).parents),
       ).toHaveLength(0);
     });
 
@@ -304,11 +308,13 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       expect(
-        queryClient.getQueryData(buildItemParentsKey(childItem.id)),
+        queryClient.getQueryData(itemKeys.single(childItem.id).parents),
       ).toBeFalsy();
       // verify cache keys
       for (const i of response) {
-        expect(queryClient.getQueryData(buildItemKey(i.id))).toBeFalsy();
+        expect(
+          queryClient.getQueryData(itemKeys.single(i.id).content),
+        ).toBeFalsy();
       }
     });
   });
@@ -323,7 +329,7 @@ describe('Items Hooks', () => {
 
       expect(data).toMatchObject(response);
       // verify cache keys
-      expect(queryClient.getQueryData(SHARED_ITEMS_KEY)).toMatchObject(
+      expect(queryClient.getQueryData(itemKeys.shared())).toMatchObject(
         response,
       );
     });
@@ -345,7 +351,7 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(SHARED_ITEMS_KEY)).toBeFalsy();
+      expect(queryClient.getQueryData(itemKeys.shared())).toBeFalsy();
     });
   });
 
@@ -356,7 +362,7 @@ describe('Items Hooks', () => {
     const items = generateFolders();
     const response = { data: items, totalCount: items.length };
     const hook = () => hooks.useAccessibleItems();
-    const key = accessibleItemsKeys.singlePage(params, pagination);
+    const key = itemKeys.accessiblePage(params, pagination);
 
     it(`Receive accessible items`, async () => {
       const endpoints = [{ route, response }];
@@ -403,7 +409,7 @@ describe('Items Hooks', () => {
     const { id } = response;
     const route = `/${buildGetItemRoute(id)}`;
     const hook = () => hooks.useItem(id);
-    const key = buildItemKey(id);
+    const key = itemKeys.single(id).content;
 
     it(`Receive item by id`, async () => {
       const endpoints = [{ route, response }];
@@ -464,11 +470,11 @@ describe('Items Hooks', () => {
       expect(data).toEqual(response);
       // verify cache keys
       const item = queryClient.getQueryData<DiscriminatedItem>(
-        buildItemKey(id),
+        itemKeys.single(id).content,
       );
       expect(item).toEqual(response.data[id]);
       const items = queryClient.getQueryData<DiscriminatedItem[]>(
-        buildItemsKey([id]),
+        itemKeys.many([id]).content,
       );
       expect(items).toEqual(response);
     });
@@ -484,12 +490,14 @@ describe('Items Hooks', () => {
 
       expect(data).toEqual(response);
       // verify cache keys
-      expect(queryClient.getQueryData(buildItemsKey(ids))).toMatchObject(data!);
+      expect(
+        queryClient.getQueryData(itemKeys.many(ids).content),
+      ).toMatchObject(data!);
       for (const item of items) {
         const itemById = items.find(({ id }) => id === item.id);
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toMatchObject(
-          itemById!,
-        );
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toMatchObject(itemById!);
       }
     });
 
@@ -507,12 +515,14 @@ describe('Items Hooks', () => {
       const { data } = await mockHook({ endpoints, hook, wrapper });
       expect(data).toEqual(response);
       // verify cache keys
-      expect(queryClient.getQueryData(buildItemsKey(ids))).toMatchObject(data!);
+      expect(
+        queryClient.getQueryData(itemKeys.many(ids).content),
+      ).toMatchObject(data!);
       for (const item of items) {
         const itemById = items.find(({ id }) => id === item.id);
-        expect(queryClient.getQueryData(buildItemKey(item.id))).toMatchObject(
-          itemById!,
-        );
+        expect(
+          queryClient.getQueryData(itemKeys.single(item.id).content),
+        ).toMatchObject(itemById!);
       }
     });
 
@@ -537,7 +547,7 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildItemsKey(ids))).toBeFalsy();
+      expect(queryClient.getQueryData(itemKeys.many(ids).content)).toBeFalsy();
     });
 
     // TODO: errors, contains errors, full errors
@@ -548,7 +558,7 @@ describe('Items Hooks', () => {
     const { id } = LocalFileItemFactory();
     const route = `/${buildDownloadFilesRoute(id)}`;
     const hook = () => hooks.useFileContent(id);
-    const key = buildFileContentKey({ id });
+    const key = itemKeys.single(id).file({ replyUrl: false });
 
     it(`Receive file content`, async () => {
       const endpoints = [{ route, response }];
@@ -614,7 +624,7 @@ describe('Items Hooks', () => {
   describe('useItemThumbnail', () => {
     const item = FolderItemFactory();
     const replyUrl = false;
-    const key = buildItemThumbnailKey({ id: item.id, replyUrl });
+    const key = itemKeys.single(item.id).thumbnail({ replyUrl });
     const response = THUMBNAIL_BLOB_RESPONSE;
     const route = `/${buildDownloadItemThumbnailRoute({
       id: item.id,
@@ -647,7 +657,7 @@ describe('Items Hooks', () => {
         replyUrl,
       })}`;
       const hookLarge = () => hooks.useItemThumbnail({ id: item.id, size });
-      const keyLarge = buildItemThumbnailKey({ id: item.id, size });
+      const keyLarge = itemKeys.single(item.id).thumbnail({ size });
 
       const endpoints = [
         {
@@ -695,7 +705,7 @@ describe('Items Hooks', () => {
         settings: { hasThumbnail: false },
       };
       queryClient.setQueryData(
-        buildItemKey(itemWithoutThumbnail.id),
+        itemKeys.single(itemWithoutThumbnail.id).content,
         itemWithoutThumbnail,
       );
       const endpoints = [
@@ -737,7 +747,7 @@ describe('Items Hooks', () => {
   describe('useItemThumbnailUrl', () => {
     const item = FolderItemFactory();
     const replyUrl = true;
-    const key = buildItemThumbnailKey({ id: item.id, replyUrl });
+    const key = itemKeys.single(item.id).thumbnail({ replyUrl });
     const response = THUMBNAIL_URL_RESPONSE;
     const route = `/${buildDownloadItemThumbnailRoute({
       id: item.id,
@@ -767,7 +777,7 @@ describe('Items Hooks', () => {
         replyUrl,
       })}`;
       const hookLarge = () => hooks.useItemThumbnailUrl({ id: item.id, size });
-      const keyLarge = buildItemThumbnailKey({ id: item.id, size, replyUrl });
+      const keyLarge = itemKeys.single(item.id).thumbnail({ size, replyUrl });
 
       const endpoints = [
         {
@@ -812,7 +822,7 @@ describe('Items Hooks', () => {
         settings: { hasThumbnail: false },
       };
       queryClient.setQueryData(
-        buildItemKey(itemWithoutThumbnail.id),
+        itemKeys.single(itemWithoutThumbnail.id).content,
         itemWithoutThumbnail,
       );
       const endpoints = [

--- a/src/hooks/itemFavorite.test.ts
+++ b/src/hooks/itemFavorite.test.ts
@@ -3,13 +3,13 @@ import { StatusCodes } from 'http-status-codes';
 import { FAVORITE_ITEM, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockHook, setUpTest } from '../../test/utils';
 import { GET_FAVORITE_ITEMS_ROUTE } from '../api/routes';
-import { FAVORITE_ITEMS_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
 describe('useFavoriteItems', () => {
   const route = `/${GET_FAVORITE_ITEMS_ROUTE}`;
-  const key = FAVORITE_ITEMS_KEY;
+  const key = memberKeys.current().favoriteItems;
 
   const hook = () => hooks.useFavoriteItems();
 

--- a/src/hooks/itemFavorite.ts
+++ b/src/hooks/itemFavorite.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 
 import * as Api from '../api';
-import { FAVORITE_ITEMS_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -9,7 +9,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useFavoriteItems = () =>
     useQuery({
-      queryKey: FAVORITE_ITEMS_KEY,
+      queryKey: memberKeys.current().favoriteItems,
       queryFn: () => Api.getFavoriteItems(queryConfig),
       ...defaultQueryOptions,
     });

--- a/src/hooks/itemGeolocation.test.ts
+++ b/src/hooks/itemGeolocation.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../api/routes';
 import {
   buildAddressFromCoordinatesKey,
-  buildItemGeolocationKey,
+  itemKeys,
   itemsWithGeolocationKeys,
 } from '../config/keys';
 
@@ -21,7 +21,7 @@ describe('useItemGeolocation', () => {
   const itemId = response.item.id;
   const route = `/${ITEMS_ROUTE}/${itemId}/geolocation`;
   const hook = () => hooks.useItemGeolocation(response.item.id);
-  const key = buildItemGeolocationKey(itemId);
+  const key = itemKeys.single(itemId).geolocation;
   const endpoints = [{ route, response }];
 
   it(`Retrieve geolocation of item`, async () => {

--- a/src/hooks/itemGeolocation.ts
+++ b/src/hooks/itemGeolocation.ts
@@ -6,7 +6,7 @@ import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
 import {
   buildAddressFromCoordinatesKey,
-  buildItemGeolocationKey,
+  itemKeys,
   itemsWithGeolocationKeys,
 } from '../config/keys';
 import {
@@ -20,7 +20,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useItemGeolocation = (id?: Item['id']) =>
     useQuery({
-      queryKey: buildItemGeolocationKey(id),
+      queryKey: itemKeys.single(id).geolocation,
       queryFn: () => {
         if (!id) {
           throw new UndefinedArgument();

--- a/src/hooks/itemLike.test.ts
+++ b/src/hooks/itemLike.test.ts
@@ -9,10 +9,7 @@ import {
   buildGetItemLikesRoute,
   buildGetLikesForMemberRoute,
 } from '../api/routes';
-import {
-  buildGetLikesForItem,
-  buildGetLikesForMemberKey,
-} from '../config/keys';
+import { itemKeys, memberKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -25,7 +22,7 @@ describe('Item Like Hooks', () => {
   describe('useLikesForMember', () => {
     const memberId = 'member-id';
     const route = `/${buildGetLikesForMemberRoute(memberId)}`;
-    const key = buildGetLikesForMemberKey(memberId);
+    const key = memberKeys.single(memberId).likedItems;
 
     const hook = () => hooks.useLikesForMember(memberId);
 
@@ -64,7 +61,7 @@ describe('Item Like Hooks', () => {
   describe('useLikesForItem', () => {
     const itemId = FolderItemFactory().id;
     const route = `/${buildGetItemLikesRoute(itemId)}`;
-    const key = buildGetLikesForItem(itemId);
+    const key = itemKeys.single(itemId).likes;
 
     const hook = () => hooks.useLikesForItem(itemId);
 

--- a/src/hooks/itemLike.ts
+++ b/src/hooks/itemLike.ts
@@ -4,10 +4,7 @@ import { useQuery } from 'react-query';
 
 import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
-import {
-  buildGetLikesForItem,
-  buildGetLikesForMemberKey,
-} from '../config/keys';
+import { itemKeys, memberKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -15,7 +12,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useLikesForMember = (memberId?: UUID) =>
     useQuery({
-      queryKey: buildGetLikesForMemberKey(memberId),
+      queryKey: memberKeys.single(memberId).likedItems,
       queryFn: () => {
         if (!memberId) {
           throw new UndefinedArgument();
@@ -28,7 +25,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useLikesForItem = (itemId?: UUID) =>
     useQuery({
-      queryKey: buildGetLikesForItem(itemId),
+      queryKey: itemKeys.single(itemId).likes,
       queryFn: () => {
         if (!itemId) {
           throw new UndefinedArgument();

--- a/src/hooks/itemLogin.ts
+++ b/src/hooks/itemLogin.ts
@@ -4,10 +4,7 @@ import { useQuery } from 'react-query';
 
 import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
-import {
-  buildItemLoginSchemaKey,
-  buildItemLoginSchemaTypeKey,
-} from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -22,7 +19,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = (options?.enabled ?? true) && Boolean(args.itemId);
       return useQuery({
-        queryKey: buildItemLoginSchemaKey(args.itemId),
+        queryKey: itemKeys.single(args.itemId).itemLoginSchema.content,
         queryFn: () => Api.getItemLoginSchema(args.itemId, queryConfig),
         ...defaultQueryOptions,
         enabled: enabledValue,
@@ -37,7 +34,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = (options?.enabled ?? true) && Boolean(args.itemId);
       return useQuery({
-        queryKey: buildItemLoginSchemaTypeKey(args.itemId),
+        queryKey: itemKeys.single(args.itemId).itemLoginSchema.type,
         queryFn: () => {
           if (!args.itemId) {
             throw new UndefinedArgument();

--- a/src/hooks/itemPublish.ts
+++ b/src/hooks/itemPublish.ts
@@ -5,14 +5,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import * as Api from '../api';
 import { splitRequestByIdsAndReturn } from '../api/axios';
 import { UndefinedArgument } from '../config/errors';
-import {
-  buildGetMostLikedPublishedItems,
-  buildGetMostRecentPublishedItems,
-  buildItemPublishedInformationKey,
-  buildManyItemPublishedInformationsKey,
-  buildPublishedItemsForMemberKey,
-  buildPublishedItemsKey,
-} from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -27,7 +20,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = options?.enabled ?? true;
       return useQuery({
-        queryKey: buildPublishedItemsKey(args?.categoryIds),
+        queryKey: itemKeys.published().forCategories(args?.categoryIds),
         queryFn: () => Api.getAllPublishedItems(args ?? {}, queryConfig),
         ...defaultQueryOptions,
         enabled: enabledValue,
@@ -41,7 +34,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = options?.enabled ?? true;
       return useQuery({
-        queryKey: buildGetMostLikedPublishedItems(args?.limit),
+        queryKey: itemKeys.published().mostLiked(args?.limit),
         queryFn: () => Api.getMostLikedPublishedItems(args ?? {}, queryConfig),
         ...defaultQueryOptions,
         enabled: enabledValue,
@@ -55,7 +48,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = options?.enabled ?? true;
       return useQuery({
-        queryKey: buildGetMostRecentPublishedItems(args?.limit),
+        queryKey: itemKeys.published().mostRecent(args?.limit),
         queryFn: () => Api.getMostRecentPublishedItems(args ?? {}, queryConfig),
         ...defaultQueryOptions,
         enabled: enabledValue,
@@ -66,7 +59,7 @@ export default (queryConfig: QueryClientConfig) => {
       options?: { enabled?: boolean },
     ) =>
       useQuery({
-        queryKey: buildPublishedItemsForMemberKey(memberId),
+        queryKey: itemKeys.published().byMember(memberId),
         queryFn: () => {
           if (!memberId) {
             throw new UndefinedArgument();
@@ -84,7 +77,7 @@ export default (queryConfig: QueryClientConfig) => {
     ) => {
       const enabledValue = (options?.enabled ?? true) && Boolean(args.itemId);
       return useQuery({
-        queryKey: buildItemPublishedInformationKey(args.itemId),
+        queryKey: itemKeys.single(args.itemId).publishedInformation,
         queryFn: () =>
           Api.getItemPublishedInformation(args.itemId, queryConfig),
         ...defaultQueryOptions,
@@ -101,7 +94,7 @@ export default (queryConfig: QueryClientConfig) => {
         (options?.enabled ?? true) && Boolean(args.itemIds.length);
       const queryClient = useQueryClient();
       return useQuery({
-        queryKey: buildManyItemPublishedInformationsKey(args.itemIds),
+        queryKey: itemKeys.many(args.itemIds).publishedInformation,
         queryFn: () =>
           splitRequestByIdsAndReturn<ItemPublished>(
             args.itemIds,
@@ -114,7 +107,10 @@ export default (queryConfig: QueryClientConfig) => {
           if (publishedData?.data) {
             Object.values(publishedData?.data)?.forEach(async (p) => {
               const { id } = p.item;
-              queryClient.setQueryData(buildItemPublishedInformationKey(id), p);
+              queryClient.setQueryData(
+                itemKeys.single(id).publishedInformation,
+                p,
+              );
             });
           }
         },

--- a/src/hooks/itemTag.test.ts
+++ b/src/hooks/itemTag.test.ts
@@ -23,7 +23,7 @@ import {
   splitEndpointByIdsForErrors,
 } from '../../test/utils';
 import { buildGetItemTagsRoute, buildGetItemsTagsRoute } from '../api/routes';
-import { itemTagsKeys } from '../config/keys';
+import { itemKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -36,7 +36,7 @@ describe('Item Tags Hooks', () => {
   describe('useItemTags', () => {
     const itemId = FolderItemFactory().id;
     const route = `/${buildGetItemTagsRoute(itemId)}`;
-    const key = itemTagsKeys.singleId(itemId);
+    const key = itemKeys.single(itemId).tags;
 
     const hook = () => hooks.useItemTags(itemId);
 
@@ -78,7 +78,7 @@ describe('Item Tags Hooks', () => {
       ({ id }) => id,
     );
 
-    const keys = itemsIds.map((itemId) => itemTagsKeys.singleId(itemId));
+    const keys = itemsIds.map((itemId) => itemKeys.single(itemId).tags);
     const tags = itemsIds.map((id) => [
       {
         id: 'some id',
@@ -154,10 +154,10 @@ describe('Item Tags Hooks', () => {
 
       // verify cache keys
       expect(
-        queryClient.getQueryData<ItemTag>(itemTagsKeys.singleId(ids[0])),
+        queryClient.getQueryData<ItemTag>(itemKeys.single(ids[0]).tags),
       ).toEqual(tagsForItem);
       expect(
-        queryClient.getQueryData(itemTagsKeys.singleId(idWithError)),
+        queryClient.getQueryData(itemKeys.single(idWithError).tags),
       ).toBeFalsy();
 
       expect(isSuccess).toBeTruthy();

--- a/src/hooks/itemTag.ts
+++ b/src/hooks/itemTag.ts
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import * as Api from '../api';
 import { splitRequestByIdsAndReturn } from '../api/axios';
 import { UndefinedArgument } from '../config/errors';
-import { itemTagsKeys } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -13,7 +13,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useItemTags = (id?: UUID) =>
     useQuery({
-      queryKey: itemTagsKeys.singleId(id),
+      queryKey: itemKeys.single(id).tags,
       queryFn: () => {
         if (!id) {
           throw new UndefinedArgument();
@@ -27,7 +27,7 @@ export default (queryConfig: QueryClientConfig) => {
   const useItemsTags = (ids?: UUID[]) => {
     const queryClient = useQueryClient();
     return useQuery({
-      queryKey: itemTagsKeys.manyIds(ids),
+      queryKey: itemKeys.many(ids).tags,
       queryFn: () => {
         if (!ids || ids?.length === 0) {
           throw new UndefinedArgument();
@@ -44,7 +44,7 @@ export default (queryConfig: QueryClientConfig) => {
         ids?.forEach(async (id) => {
           const itemTags = tags?.data?.[id];
           if (itemTags?.length) {
-            queryClient.setQueryData(itemTagsKeys.singleId(id), itemTags);
+            queryClient.setQueryData(itemKeys.single(id).tags, itemTags);
           }
         });
       },

--- a/src/hooks/itemValidation.test.ts
+++ b/src/hooks/itemValidation.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../test/constants';
 import { mockHook, setUpTest } from '../../test/utils';
 import { buildGetLastItemValidationGroupRoute } from '../api/routes';
-import { buildLastItemValidationGroupKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -20,7 +20,7 @@ describe('Item Validation Hooks', () => {
   describe('useLastItemValidationGroup', () => {
     const iVId = 'item-validation-id';
     const route = `/${buildGetLastItemValidationGroupRoute(iVId)}`;
-    const key = buildLastItemValidationGroupKey(iVId);
+    const key = itemKeys.single(iVId).validation;
 
     const hook = () => hooks.useLastItemValidationGroup(iVId);
 

--- a/src/hooks/itemValidation.ts
+++ b/src/hooks/itemValidation.ts
@@ -3,7 +3,7 @@ import { UUID } from '@graasp/sdk';
 import { useQuery } from 'react-query';
 
 import * as Api from '../api';
-import { buildLastItemValidationGroupKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -12,7 +12,7 @@ export default (queryConfig: QueryClientConfig) => {
   // get last validation joined with review records of given item
   const useLastItemValidationGroup = (itemId: UUID) =>
     useQuery({
-      queryKey: buildLastItemValidationGroupKey(itemId),
+      queryKey: itemKeys.single(itemId).validation,
       queryFn: () => Api.getLastItemValidationGroup(queryConfig, itemId),
       ...defaultQueryOptions,
       enabled: Boolean(itemId),

--- a/src/hooks/member.test.ts
+++ b/src/hooks/member.test.ts
@@ -27,13 +27,7 @@ import {
   buildGetMemberStorage,
   buildGetMembersRoute,
 } from '../api/routes';
-import {
-  CURRENT_MEMBER_KEY,
-  CURRENT_MEMBER_STORAGE_KEY,
-  buildAvatarKey,
-  buildMemberKey,
-  buildMembersKey,
-} from '../config/keys';
+import { memberKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 describe('Member Hooks', () => {
@@ -53,7 +47,9 @@ describe('Member Hooks', () => {
 
       expect(data).toMatchObject(response);
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toMatchObject(data!);
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toMatchObject(data!);
     });
 
     it(`Unauthorized`, async () => {
@@ -73,7 +69,7 @@ describe('Member Hooks', () => {
       // unauthorized request are translated to signed out user
       expect(data).toBeNull();
       expect(isSuccess).toBeTruthy();
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeNull();
+      expect(queryClient.getQueryData(memberKeys.current().content)).toBeNull();
     });
   });
 
@@ -97,7 +93,9 @@ describe('Member Hooks', () => {
 
       expect(data).toMatchObject(response);
       // verify cache keys
-      expect(queryClient.getQueryData(buildMemberKey(id))).toMatchObject(data!);
+      expect(
+        queryClient.getQueryData(memberKeys.single(id).content),
+      ).toMatchObject(data!);
     });
 
     it(`Unauthorized`, async () => {
@@ -118,7 +116,9 @@ describe('Member Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildMemberKey(id))).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.single(id).content),
+      ).toBeFalsy();
     });
   });
 
@@ -144,7 +144,7 @@ describe('Member Hooks', () => {
 
       expect(data).toBeFalsy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildMembersKey(emptyIds))).toBeFalsy();
+      expect(queryClient.getQueryData(memberKeys.many(emptyIds))).toBeFalsy();
     });
 
     it(`Receive one member`, async () => {
@@ -166,10 +166,12 @@ describe('Member Hooks', () => {
 
       expect(members).toEqual(oneMemberResponse);
       // verify cache keys
-      expect(queryClient.getQueryData(buildMembersKey(oneMemberIds))).toEqual(
+      expect(queryClient.getQueryData(memberKeys.many(oneMemberIds))).toEqual(
         members,
       );
-      expect(queryClient.getQueryData(buildMemberKey(m.id))).toMatchObject(m);
+      expect(
+        queryClient.getQueryData(memberKeys.single(m.id).content),
+      ).toMatchObject(m);
     });
 
     it(`Receive two members`, async () => {
@@ -192,11 +194,11 @@ describe('Member Hooks', () => {
       expect(members).toEqual(endpointResponse);
       // verify cache keys
       expect(
-        queryClient.getQueryData<ResultOf<Member>>(buildMembersKey(twoIds)),
+        queryClient.getQueryData<ResultOf<Member>>(memberKeys.many(twoIds)),
       ).toEqual(endpointResponse);
       for (const id of twoIds) {
         expect(
-          queryClient.getQueryData<Member>(buildMemberKey(id)),
+          queryClient.getQueryData<Member>(memberKeys.single(id).content),
         ).toMatchObject(twoMembers.find(({ id: thisId }) => thisId === id)!);
       }
     });
@@ -220,11 +222,11 @@ describe('Member Hooks', () => {
       expect(members).toEqual(fullResponse);
       // verify cache keys
       expect(
-        queryClient.getQueryData<ResultOf<Member>>(buildMembersKey(ids)),
+        queryClient.getQueryData<ResultOf<Member>>(memberKeys.many(ids)),
       ).toEqual(fullResponse);
       for (const id of ids) {
         expect(
-          queryClient.getQueryData<Member>(buildMemberKey(id)),
+          queryClient.getQueryData<Member>(memberKeys.single(id).content),
         ).toMatchObject(response.find(({ id: thisId }) => thisId === id)!);
       }
     });
@@ -247,10 +249,10 @@ describe('Member Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildMembersKey(ids))).toBeFalsy();
+      expect(queryClient.getQueryData(memberKeys.many(ids))).toBeFalsy();
       for (const id of ids) {
         expect(
-          queryClient.getQueryData<Member>(buildMemberKey(id)),
+          queryClient.getQueryData<Member>(memberKeys.single(id).content),
         ).toBeFalsy();
       }
     });
@@ -264,7 +266,7 @@ describe('Member Hooks', () => {
     const response = AVATAR_BLOB_RESPONSE;
     const route = `/${buildDownloadAvatarRoute({ id: member.id, replyUrl })}`;
     const hook = () => hooks.useAvatar({ id: member.id });
-    const key = buildAvatarKey({ id: member.id, replyUrl });
+    const key = memberKeys.single(member.id).avatar({ replyUrl });
 
     it(`Receive default avatar`, async () => {
       const endpoints = [
@@ -285,7 +287,7 @@ describe('Member Hooks', () => {
         size,
       })}`;
       const hookLarge = () => hooks.useAvatar({ id: member.id, size });
-      const keyLarge = buildAvatarKey({ id: member.id, size, replyUrl });
+      const keyLarge = memberKeys.single(member.id).avatar({ size, replyUrl });
 
       const endpoints = [
         {
@@ -369,7 +371,7 @@ describe('Member Hooks', () => {
     const response = AVATAR_URL_RESPONSE;
     const route = `/${buildDownloadAvatarRoute({ id: member.id, replyUrl })}`;
     const hook = () => hooks.useAvatarUrl({ id: member.id });
-    const key = buildAvatarKey({ id: member.id, replyUrl });
+    const key = memberKeys.single(member.id).avatar({ replyUrl });
 
     it(`Receive default avatar url`, async () => {
       const endpoints = [{ route, response }];
@@ -387,7 +389,7 @@ describe('Member Hooks', () => {
         size,
       })}`;
       const hookLarge = () => hooks.useAvatarUrl({ id: member.id, size });
-      const keyLarge = buildAvatarKey({ id: member.id, size, replyUrl });
+      const keyLarge = memberKeys.single(member.id).avatar({ size, replyUrl });
 
       const endpoints = [
         {
@@ -468,7 +470,7 @@ describe('Member Hooks', () => {
     const response: MemberStorage = { current: 123, maximum: 123 };
     const route = `/${buildGetMemberStorage()}`;
     const hook = () => hooks.useMemberStorage();
-    const key = CURRENT_MEMBER_STORAGE_KEY;
+    const key = memberKeys.current().storage;
 
     it(`Receive member storage`, async () => {
       const endpoints = [{ route, response }];

--- a/src/hooks/plan.ts
+++ b/src/hooks/plan.ts
@@ -4,9 +4,8 @@ import * as Api from '../api';
 import {
   CARDS_KEY,
   CURRENT_CUSTOMER_KEY,
-  OWN_PLAN_KEY,
   PLANS_KEY,
-  buildPlanKey,
+  memberKeys,
 } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
@@ -15,7 +14,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const usePlan = ({ planId }: { planId: string }) =>
     useQuery({
-      queryKey: buildPlanKey(planId),
+      queryKey: memberKeys.single().subscription(planId),
       queryFn: () => Api.getPlan({ planId }, queryConfig),
       ...defaultOptions,
     });
@@ -29,7 +28,7 @@ export default (queryConfig: QueryClientConfig) => {
 
   const useOwnPlan = () =>
     useQuery({
-      queryKey: OWN_PLAN_KEY,
+      queryKey: memberKeys.current().subscription,
       queryFn: () => Api.getOwnPlan(queryConfig),
       ...defaultOptions,
     });

--- a/src/hooks/publicProfile.test.ts
+++ b/src/hooks/publicProfile.test.ts
@@ -11,7 +11,7 @@ import {
   MEMBERS_ROUTE,
   buildGetPublicProfileRoute,
 } from '../api/routes';
-import { OWN_PUBLIC_PROFILE_KEY, buildPublicProfileKey } from '../config/keys';
+import { memberKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -31,7 +31,7 @@ describe('Public Profile Hooks', () => {
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
       expect(data).toEqual(response);
-      expect(queryClient.getQueryData(OWN_PUBLIC_PROFILE_KEY)).toEqual(
+      expect(queryClient.getQueryData(memberKeys.current().profile)).toEqual(
         response,
       );
     });
@@ -51,7 +51,9 @@ describe('Public Profile Hooks', () => {
       });
 
       expect(isError).toBeTruthy();
-      expect(queryClient.getQueryData(OWN_PUBLIC_PROFILE_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().profile),
+      ).toBeFalsy();
     });
   });
 
@@ -72,7 +74,7 @@ describe('Public Profile Hooks', () => {
         wrapper,
         endpoints,
       });
-      expect(queryClient.getQueryData(buildPublicProfileKey(id))).toEqual(
+      expect(queryClient.getQueryData(memberKeys.single(id).profile)).toEqual(
         response,
       );
       expect(data).toMatchObject(response);

--- a/src/hooks/publicProfile.ts
+++ b/src/hooks/publicProfile.ts
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query';
 
 import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
-import { OWN_PUBLIC_PROFILE_KEY, buildPublicProfileKey } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -13,14 +13,14 @@ export default (queryConfig: QueryClientConfig) => {
   return {
     useOwnProfile: () =>
       useQuery({
-        queryKey: OWN_PUBLIC_PROFILE_KEY,
+        queryKey: memberKeys.current().profile,
         queryFn: () => Api.getOwnProfile(queryConfig),
         ...defaultQueryOptions,
       }),
 
     usePublicProfile: (memberId?: UUID) =>
       useQuery({
-        queryKey: buildPublicProfileKey(memberId),
+        queryKey: memberKeys.single(memberId).profile,
         queryFn: () => {
           if (!memberId) {
             throw new UndefinedArgument();

--- a/src/hooks/search.test.ts
+++ b/src/hooks/search.test.ts
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 import { mockHook, setUpTest } from '../../test/utils';
 import { SEARCH_PUBLISHED_ITEMS_ROUTE } from '../api/routes';
-import { buildSearchPublishedItemsKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 
 const { hooks, wrapper, queryClient } = setUpTest();
 
@@ -105,7 +105,7 @@ describe('Published Search Hook', () => {
       const categories = [['mycategoryid']];
       const hook = () =>
         hooks.useSearchPublishedItems({ query, categories, page: 1 });
-      const key = buildSearchPublishedItemsKey({
+      const key = itemKeys.search({
         query,
         categories,
         page: 1,
@@ -126,7 +126,7 @@ describe('Published Search Hook', () => {
 
     it(`does not fetch if no query nor categories is provided`, async () => {
       const hook = () => hooks.useSearchPublishedItems({});
-      const key = buildSearchPublishedItemsKey({ page: 1 });
+      const key = itemKeys.search({ page: 1 });
       const endpoints = [{ route, response: RESPONSE }];
       const { data, isFetched } = await mockHook({
         endpoints,
@@ -146,7 +146,7 @@ describe('Published Search Hook', () => {
       const categories = [['mycategoryid']];
       const isPublishedRoot = true;
       const spy = jest.spyOn(axios, 'post');
-      const key = buildSearchPublishedItemsKey({
+      const key = itemKeys.search({
         isPublishedRoot,
         query,
         categories,
@@ -197,7 +197,7 @@ describe('Published Search Hook', () => {
       const isPublishedRoot = true;
       const page = 3;
       const spy = jest.spyOn(axios, 'post');
-      const key = buildSearchPublishedItemsKey({
+      const key = itemKeys.search({
         isPublishedRoot,
         query,
         categories,
@@ -246,7 +246,7 @@ describe('Published Search Hook', () => {
       const query = 'some string';
       const categories = [['mycategoryid']];
       const isPublishedRoot = true;
-      const key = buildSearchPublishedItemsKey({
+      const key = itemKeys.search({
         isPublishedRoot,
         query,
         categories,

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -3,7 +3,7 @@ import { Category } from '@graasp/sdk';
 import { useQuery } from 'react-query';
 
 import * as Api from '../api';
-import { buildSearchPublishedItemsKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 import useDebounce from './useDebounce';
 
@@ -34,7 +34,7 @@ export default (queryConfig: QueryClientConfig) => {
     } & Api.MeiliSearchProps) => {
       const debouncedQuery = useDebounce(query, 500);
       return useQuery({
-        queryKey: buildSearchPublishedItemsKey({
+        queryKey: itemKeys.search({
           query: debouncedQuery,
           categories,
           isPublishedRoot,

--- a/src/hooks/shortLink.ts
+++ b/src/hooks/shortLink.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query';
 
 import * as Api from '../api';
 import { UndefinedArgument } from '../config/errors';
-import { buildShortLinkKey, buildShortLinksItemKey } from '../config/keys';
+import { buildShortLinkKey, itemKeys } from '../config/keys';
 import { QueryClientConfig } from '../types';
 
 export default (queryConfig: QueryClientConfig) => {
@@ -24,7 +24,7 @@ export default (queryConfig: QueryClientConfig) => {
 
     useShortLinksItem: (itemId: string) =>
       useQuery({
-        queryKey: buildShortLinksItemKey(itemId),
+        queryKey: itemKeys.single(itemId).shortLinks,
         queryFn: () => Api.getShortLinksItem(itemId, queryConfig),
         enabled: true,
         ...defaultQueryOptions,

--- a/src/mutations/authentication.test.ts
+++ b/src/mutations/authentication.test.ts
@@ -19,7 +19,7 @@ import {
   SIGN_UP_ROUTE,
   buildUpdateMemberPasswordRoute,
 } from '../api/routes';
-import { CURRENT_MEMBER_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import {
   signInRoutine,
   signInWithPasswordRoutine,
@@ -188,7 +188,7 @@ describe('Authentication Mutations', () => {
         },
       ];
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, 'somevalue');
+      queryClient.setQueryData(memberKeys.current().content, 'somevalue');
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -202,7 +202,9 @@ describe('Authentication Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toBeFalsy();
 
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: signInWithPasswordRoutine.SUCCESS,
@@ -255,7 +257,7 @@ describe('Authentication Mutations', () => {
         },
       ];
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, 'somevalue');
+      queryClient.setQueryData(memberKeys.current().content, 'somevalue');
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -269,7 +271,9 @@ describe('Authentication Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toBeFalsy();
 
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: signInWithPasswordRoutine.SUCCESS,
@@ -488,7 +492,7 @@ describe('Authentication Mutations', () => {
 
     it(`Sign out`, async () => {
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, 'somevalue');
+      queryClient.setQueryData(memberKeys.current().content, 'somevalue');
 
       const endpoints = [
         { route, response: OK_RESPONSE, method: HttpMethod.GET },
@@ -509,7 +513,9 @@ describe('Authentication Mutations', () => {
         type: signOutRoutine.SUCCESS,
         payload: { message: SUCCESS_MESSAGES.SIGN_OUT },
       });
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toBeFalsy();
 
       // cookie management
       expect(utils.saveUrlForRedirection).toHaveBeenCalled();

--- a/src/mutations/authentication.ts
+++ b/src/mutations/authentication.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { CURRENT_MEMBER_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import {
   signInRoutine,
   signInWithPasswordRoutine,
@@ -211,7 +211,7 @@ export default (queryConfig: QueryClientConfig) => {
         }
         // Update when the server confirmed the logout, instead optimistically updating the member
         // This prevents logout loop (redirect to logout -> still cookie -> logs back in)
-        queryClient.setQueryData(CURRENT_MEMBER_KEY, undefined);
+        queryClient.setQueryData(memberKeys.current().content, undefined);
       },
       onError: (error: Error) => {
         notifier?.({

--- a/src/mutations/itemCategory.test.ts
+++ b/src/mutations/itemCategory.test.ts
@@ -12,7 +12,7 @@ import {
   buildDeleteItemCategoryRoute,
   buildPostItemCategoryRoute,
 } from '../api/routes';
-import { buildItemCategoriesKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import {
   deleteItemCategoryRoutine,
   postItemCategoryRoutine,
@@ -34,7 +34,7 @@ describe('Item Category Mutations', () => {
     const categoryId = 'new-category';
     const route = `/${buildPostItemCategoryRoute(itemId)}`;
     const mutation = mutations.usePostItemCategory;
-    const key = buildItemCategoriesKey(itemId);
+    const key = itemKeys.single(itemId).categories;
 
     it('Post item category', async () => {
       queryClient.setQueryData(key, ITEM_CATEGORIES);
@@ -106,7 +106,7 @@ describe('Item Category Mutations', () => {
       itemCategoryId,
     })}`;
     const mutation = mutations.useDeleteItemCategory;
-    const key = buildItemCategoriesKey(itemId);
+    const key = itemKeys.single(itemId).categories;
 
     it('Delete item category', async () => {
       queryClient.setQueryData(key, ITEM_CATEGORIES);

--- a/src/mutations/itemCategory.ts
+++ b/src/mutations/itemCategory.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { buildItemCategoriesKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import {
   deleteItemCategoryRoutine,
   postItemCategoryRoutine,
@@ -33,7 +33,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemCategoriesKey(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).categories);
         },
       },
     );
@@ -58,7 +58,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemCategoriesKey(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).categories);
         },
       },
     );

--- a/src/mutations/itemFavorite.test.ts
+++ b/src/mutations/itemFavorite.test.ts
@@ -7,7 +7,7 @@ import nock from 'nock';
 import { UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildFavoriteItemRoute } from '../api/routes';
-import { FAVORITE_ITEMS_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { addFavoriteItemRoutine, deleteFavoriteItemRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -27,7 +27,7 @@ describe('Favorite Mutations', () => {
 
     it(`Successfully add favorite item`, async () => {
       // set random data in cache
-      queryClient.setQueryData(FAVORITE_ITEMS_KEY, 'mock');
+      queryClient.setQueryData(memberKeys.current().favoriteItems, 'mock');
       const endpoints = [
         {
           response: itemId,
@@ -42,12 +42,13 @@ describe('Favorite Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate(itemId);
+        mockedMutation.mutate(itemId);
         await waitForMutation();
       });
 
       expect(
-        queryClient.getQueryState(FAVORITE_ITEMS_KEY)?.isInvalidated,
+        queryClient.getQueryState(memberKeys.current().favoriteItems)
+          ?.isInvalidated,
       ).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: addFavoriteItemRoutine.SUCCESS,
@@ -71,7 +72,7 @@ describe('Favorite Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate(itemId);
+        mockedMutation.mutate(itemId);
         await waitForMutation();
       });
 
@@ -89,7 +90,7 @@ describe('Favorite Mutations', () => {
     const mutation = mutations.useRemoveFavoriteItem;
 
     it('Delete item like', async () => {
-      queryClient.setQueryData(FAVORITE_ITEMS_KEY, itemId);
+      queryClient.setQueryData(memberKeys.current().favoriteItems, itemId);
 
       const endpoints = [
         {
@@ -106,12 +107,13 @@ describe('Favorite Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate(itemId);
+        mockedMutation.mutate(itemId);
         await waitForMutation();
       });
 
       expect(
-        queryClient.getQueryState(FAVORITE_ITEMS_KEY)?.isInvalidated,
+        queryClient.getQueryState(memberKeys.current().favoriteItems)
+          ?.isInvalidated,
       ).toBeTruthy();
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: deleteFavoriteItemRoutine.SUCCESS,
@@ -135,7 +137,7 @@ describe('Favorite Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate(itemId);
+        mockedMutation.mutate(itemId);
         await waitForMutation();
       });
 

--- a/src/mutations/itemFavorite.ts
+++ b/src/mutations/itemFavorite.ts
@@ -3,7 +3,7 @@ import { UUID } from '@graasp/sdk';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { FAVORITE_ITEMS_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { addFavoriteItemRoutine, deleteFavoriteItemRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -25,7 +25,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: () => {
-          queryClient.invalidateQueries(FAVORITE_ITEMS_KEY);
+          queryClient.invalidateQueries(memberKeys.current().favoriteItems);
         },
       },
     );
@@ -46,7 +46,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: () => {
-          queryClient.invalidateQueries(FAVORITE_ITEMS_KEY);
+          queryClient.invalidateQueries(memberKeys.current().favoriteItems);
         },
       },
     );

--- a/src/mutations/itemFlag.test.ts
+++ b/src/mutations/itemFlag.test.ts
@@ -8,7 +8,7 @@ import { act } from 'react-test-renderer';
 import { ITEM_FLAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildPostItemFlagRoute } from '../api/routes';
-import { buildItemFlagsKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { postItemFlagRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -25,7 +25,7 @@ describe('Item Flag Mutations', () => {
   describe('usePostItemFlag', () => {
     const flagType = FlagType.FalseInformation;
     const itemId = FolderItemFactory().id;
-    const flagKey = buildItemFlagsKey(itemId);
+    const flagKey = itemKeys.single(itemId).flags;
     const route = `/${buildPostItemFlagRoute(itemId)}`;
     const mutation = mutations.usePostItemFlag;
 

--- a/src/mutations/itemFlag.ts
+++ b/src/mutations/itemFlag.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { buildItemFlagsKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { postItemFlagRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -28,7 +28,7 @@ export default (queryConfig: QueryClientConfig) => {
           notifier?.({ type: postItemFlagRoutine.FAILURE, payload: { error } });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemFlagsKey(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).flags);
         },
       },
     );

--- a/src/mutations/itemGeolocation.test.ts
+++ b/src/mutations/itemGeolocation.test.ts
@@ -9,10 +9,7 @@ import { v4 } from 'uuid';
 import { ITEM_GEOLOCATION, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildPutItemGeolocationRoute } from '../api/routes';
-import {
-  buildItemGeolocationKey,
-  itemsWithGeolocationKeys,
-} from '../config/keys';
+import { itemKeys, itemsWithGeolocationKeys } from '../config/keys';
 import {
   deleteItemGeolocationRoutine,
   putItemGeolocationRoutine,
@@ -31,7 +28,7 @@ describe('Item Flag Mutations', () => {
 
   describe('usePutItemGeolocation', () => {
     const itemId = v4();
-    const key = buildItemGeolocationKey(itemId);
+    const key = itemKeys.single(itemId).geolocation;
     const route = `/${buildPutItemGeolocationRoute(itemId)}`;
     const mutation = mutations.usePutItemGeolocation;
     const singleKey = itemsWithGeolocationKeys.inBounds({
@@ -161,7 +158,7 @@ describe('Item Flag Mutations', () => {
 
   describe('useDeleteItemGeolocation', () => {
     const itemId = v4();
-    const key = buildItemGeolocationKey(itemId);
+    const key = itemKeys.single(itemId).geolocation;
     const route = `/${buildPutItemGeolocationRoute(itemId)}`;
     const mutation = mutations.useDeleteItemGeolocation;
     const singleKey = itemsWithGeolocationKeys.inBounds({

--- a/src/mutations/itemGeolocation.ts
+++ b/src/mutations/itemGeolocation.ts
@@ -4,10 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import { deleteItemGeolocation, putItemGeolocation } from '../api';
-import {
-  buildItemGeolocationKey,
-  itemsWithGeolocationKeys,
-} from '../config/keys';
+import { itemKeys, itemsWithGeolocationKeys } from '../config/keys';
 import {
   deleteItemGeolocationRoutine,
   putItemGeolocationRoutine,
@@ -37,7 +34,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemGeolocationKey(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).geolocation);
           queryClient.invalidateQueries(itemsWithGeolocationKeys.allBounds);
         },
       },
@@ -63,7 +60,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemGeolocationKey(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).geolocation);
           queryClient.invalidateQueries(itemsWithGeolocationKeys.allBounds);
         },
       },

--- a/src/mutations/itemLike.test.ts
+++ b/src/mutations/itemLike.test.ts
@@ -10,7 +10,7 @@ import {
   buildDeleteItemLikeRoute,
   buildPostItemLikeRoute,
 } from '../api/routes';
-import { buildGetLikesForMemberKey } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { deleteItemLikeRoutine, postItemLikeRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -28,7 +28,7 @@ describe('Item Like Mutations', () => {
   describe('usePostItemLike', () => {
     const itemId = FolderItemFactory().id;
     const memberId = MemberFactory().id;
-    const likedItemsKey = buildGetLikesForMemberKey(memberId);
+    const likedItemsKey = memberKeys.single(memberId).likedItems;
     const route = `/${buildPostItemLikeRoute(itemId)}`;
     const mutation = mutations.usePostItemLike;
 
@@ -96,7 +96,7 @@ describe('Item Like Mutations', () => {
   describe('useDeleteItemLike', () => {
     const itemId = FolderItemFactory().id;
     const memberId = MemberFactory().id;
-    const likedItemsKey = buildGetLikesForMemberKey(memberId);
+    const likedItemsKey = memberKeys.single(memberId).likedItems;
     const route = `/${buildDeleteItemLikeRoute(itemId)}`;
     const mutation = mutations.useDeleteItemLike;
 

--- a/src/mutations/itemLike.ts
+++ b/src/mutations/itemLike.ts
@@ -3,10 +3,7 @@ import { ItemLike, Member, UUID } from '@graasp/sdk';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import {
-  buildGetLikesForItem,
-  buildGetLikesForMemberKey,
-} from '../config/keys';
+import { itemKeys, memberKeys } from '../config/keys';
 import { deleteItemLikeRoutine, postItemLikeRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -27,8 +24,8 @@ export default (queryConfig: QueryClientConfig) => {
         notifier?.({ type: postItemLikeRoutine.FAILURE, payload: { error } });
       },
       onSettled: (_data, _error, { memberId, itemId }) => {
-        queryClient.invalidateQueries(buildGetLikesForMemberKey(memberId));
-        queryClient.invalidateQueries(buildGetLikesForItem(itemId));
+        queryClient.invalidateQueries(memberKeys.single(memberId).likedItems);
+        queryClient.invalidateQueries(itemKeys.single(itemId).likes);
       },
     });
   };
@@ -50,8 +47,8 @@ export default (queryConfig: QueryClientConfig) => {
         });
       },
       onSettled: (_data, _error, { memberId, itemId }) => {
-        queryClient.invalidateQueries(buildGetLikesForMemberKey(memberId));
-        queryClient.invalidateQueries(buildGetLikesForItem(itemId));
+        queryClient.invalidateQueries(memberKeys.single(memberId).likedItems);
+        queryClient.invalidateQueries(itemKeys.single(itemId).likes);
       },
     });
   };

--- a/src/mutations/itemLogin.test.ts
+++ b/src/mutations/itemLogin.test.ts
@@ -16,11 +16,7 @@ import {
   buildPostItemLoginSignInRoute,
   buildPutItemLoginSchemaRoute,
 } from '../api/routes';
-import {
-  CURRENT_MEMBER_KEY,
-  OWN_ITEMS_KEY,
-  buildItemLoginSchemaKey,
-} from '../config/keys';
+import { OWN_ITEMS_KEY, itemKeys, memberKeys } from '../config/keys';
 import { postItemLoginRoutine, putItemLoginSchemaRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -42,7 +38,7 @@ describe('Item Login Mutations', () => {
     const route = `/${buildPostItemLoginSignInRoute(itemId)}`;
     const mutation = mutations.usePostItemLogin;
     it('Post item login', async () => {
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, MemberFactory());
+      queryClient.setQueryData(memberKeys.current().content, MemberFactory());
       // todo: change to Accessible ?
       queryClient.setQueryData(OWN_ITEMS_KEY, items);
 
@@ -71,13 +67,15 @@ describe('Item Login Mutations', () => {
       });
 
       // check all set keys are reset
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toBeFalsy();
       // todo: change to Accessible
       expect(queryClient.getQueryData(OWN_ITEMS_KEY)).toBeFalsy();
     });
 
     it('Unauthorized to post item login', async () => {
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, MemberFactory());
+      queryClient.setQueryData(memberKeys.current().content, MemberFactory());
       // todo: change to Accessible ?
       queryClient.setQueryData(OWN_ITEMS_KEY, items);
 
@@ -107,7 +105,9 @@ describe('Item Login Mutations', () => {
       });
 
       // check all set keys are reset
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toBeFalsy();
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toBeFalsy();
       // todo: change to Accessible ?
       expect(queryClient.getQueryData(OWN_ITEMS_KEY)).toBeFalsy();
 
@@ -123,7 +123,7 @@ describe('Item Login Mutations', () => {
     const route = `/${buildPutItemLoginSchemaRoute(itemId)}`;
     const mutation = mutations.usePutItemLoginSchema;
     const loginSchema = ITEM_LOGIN_RESPONSE;
-    const itemLoginKey = buildItemLoginSchemaKey(itemId);
+    const itemLoginKey = itemKeys.single(itemId).itemLoginSchema.content;
     const newLoginSchema = ItemLoginSchemaType.UsernameAndPassword;
 
     it('Put item login schema', async () => {

--- a/src/mutations/itemLogin.ts
+++ b/src/mutations/itemLogin.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { buildItemLoginSchemaKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import {
   deleteItemLoginSchemaRoutine,
   postItemLoginRoutine,
@@ -58,7 +58,9 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(buildItemLoginSchemaKey(itemId));
+          queryClient.invalidateQueries(
+            itemKeys.single(itemId).itemLoginSchema.content,
+          );
         },
       },
     );
@@ -71,7 +73,7 @@ export default (queryConfig: QueryClientConfig) => {
         Api.deleteItemLoginSchema(payload, queryConfig),
       {
         onMutate: ({ itemId }) => {
-          const key = buildItemLoginSchemaKey(itemId);
+          const key = itemKeys.single(itemId).itemLoginSchema.content;
           const previous = queryClient.getQueryData(key);
           queryClient.setQueryData(key, null);
           return previous;
@@ -87,12 +89,17 @@ export default (queryConfig: QueryClientConfig) => {
             type: deleteItemLoginSchemaRoutine.FAILURE,
             payload: { error },
           });
-          queryClient.setQueryData(buildItemLoginSchemaKey(itemId), previous);
+          queryClient.setQueryData(
+            itemKeys.single(itemId).itemLoginSchema.content,
+            previous,
+          );
         },
         onSettled: (_data, _error, { itemId }) => {
           // it is not necessary to update the cache for the given item login schema
           // because the item login only applies if the user is signed out
-          queryClient.invalidateQueries(buildItemLoginSchemaKey(itemId));
+          queryClient.invalidateQueries(
+            itemKeys.single(itemId).itemLoginSchema.content,
+          );
         },
       },
     );

--- a/src/mutations/itemPublish.test.ts
+++ b/src/mutations/itemPublish.test.ts
@@ -12,12 +12,7 @@ import {
 } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildItemPublishRoute } from '../api/routes';
-import {
-  CURRENT_MEMBER_KEY,
-  buildItemPublishedInformationKey,
-  buildPublishedItemsForMemberKey,
-  buildPublishedItemsKey,
-} from '../config/keys';
+import { itemKeys, memberKeys } from '../config/keys';
 import { publishItemRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -43,15 +38,15 @@ describe('Publish Item', () => {
     it('Publish Item with notification', async () => {
       const route = `/${buildItemPublishRoute(itemId, notification)}`;
       queryClient.setQueryData(
-        buildItemPublishedInformationKey(itemId),
+        itemKeys.single(itemId).publishedInformation,
         ITEM_PUBLISHED_DATA,
       );
       queryClient.setQueryData(
-        buildPublishedItemsForMemberKey(currentMemberId),
+        itemKeys.published().byMember(currentMemberId),
         items,
       );
-      queryClient.setQueryData(buildPublishedItemsKey(), items);
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, currentMember);
+      queryClient.setQueryData(itemKeys.published().forCategories(), items);
+      queryClient.setQueryData(memberKeys.current().content, currentMember);
 
       const endpoints = [
         {
@@ -78,16 +73,17 @@ describe('Publish Item', () => {
       expect(route.includes('notification'));
 
       expect(
-        queryClient.getQueryState(buildItemPublishedInformationKey(itemId))
+        queryClient.getQueryState(itemKeys.single(itemId).publishedInformation)
           ?.isInvalidated,
       ).toBeTruthy();
       expect(
         queryClient.getQueryState(
-          buildPublishedItemsForMemberKey(currentMemberId),
+          itemKeys.published().byMember(currentMemberId),
         )?.isInvalidated,
       ).toBeTruthy();
       expect(
-        queryClient.getQueryState(buildPublishedItemsKey())?.isInvalidated,
+        queryClient.getQueryState(itemKeys.published().forCategories())
+          ?.isInvalidated,
       ).toBeTruthy();
 
       expect(mockedNotifier).toHaveBeenCalledWith({
@@ -98,15 +94,15 @@ describe('Publish Item', () => {
     it('Publish Item without notification', async () => {
       const route = `/${buildItemPublishRoute(itemId)}`;
       queryClient.setQueryData(
-        buildItemPublishedInformationKey(itemId),
+        itemKeys.single(itemId).publishedInformation,
         ITEM_PUBLISHED_DATA,
       );
       queryClient.setQueryData(
-        buildPublishedItemsForMemberKey(currentMemberId),
+        itemKeys.published().byMember(currentMemberId),
         items,
       );
-      queryClient.setQueryData(buildPublishedItemsKey(), items);
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, currentMember);
+      queryClient.setQueryData(itemKeys.published().forCategories(), items);
+      queryClient.setQueryData(memberKeys.current().content, currentMember);
 
       const endpoints = [
         {
@@ -131,16 +127,17 @@ describe('Publish Item', () => {
       });
 
       expect(
-        queryClient.getQueryState(buildItemPublishedInformationKey(itemId))
+        queryClient.getQueryState(itemKeys.single(itemId).publishedInformation)
           ?.isInvalidated,
       ).toBeTruthy();
       expect(
         queryClient.getQueryState(
-          buildPublishedItemsForMemberKey(currentMemberId),
+          itemKeys.published().byMember(currentMemberId),
         )?.isInvalidated,
       ).toBeTruthy();
       expect(
-        queryClient.getQueryState(buildPublishedItemsKey())?.isInvalidated,
+        queryClient.getQueryState(itemKeys.published().forCategories())
+          ?.isInvalidated,
       ).toBeTruthy();
 
       expect(mockedNotifier).toHaveBeenCalledWith({

--- a/src/mutations/itemPublish.ts
+++ b/src/mutations/itemPublish.ts
@@ -3,12 +3,7 @@ import { CompleteMember, UUID } from '@graasp/sdk';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import {
-  CURRENT_MEMBER_KEY,
-  buildItemPublishedInformationKey,
-  buildPublishedItemsForMemberKey,
-  buildPublishedItemsKey,
-} from '../config/keys';
+import { itemKeys, memberKeys } from '../config/keys';
 import { publishItemRoutine, unpublishItemRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -31,15 +26,18 @@ export default (queryConfig: QueryClientConfig) => {
           notifier?.({ type: publishItemRoutine.FAILURE, payload: { error } });
         },
         onSettled: (_data, _error, { id }) => {
-          queryClient.invalidateQueries(buildItemPublishedInformationKey(id));
-          const currentMemberId =
-            queryClient.getQueryData<CompleteMember>(CURRENT_MEMBER_KEY)?.id;
+          queryClient.invalidateQueries(
+            itemKeys.single(id).publishedInformation,
+          );
+          const currentMemberId = queryClient.getQueryData<CompleteMember>(
+            memberKeys.current().content,
+          )?.id;
           if (currentMemberId) {
             queryClient.invalidateQueries(
-              buildPublishedItemsForMemberKey(currentMemberId),
+              itemKeys.published().byMember(currentMemberId),
             );
           }
-          queryClient.invalidateQueries(buildPublishedItemsKey());
+          queryClient.invalidateQueries(itemKeys.published().all);
         },
       },
     );
@@ -60,15 +58,18 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { id }) => {
-          queryClient.invalidateQueries(buildItemPublishedInformationKey(id));
-          const currentMemberId =
-            queryClient.getQueryData<CompleteMember>(CURRENT_MEMBER_KEY)?.id;
+          queryClient.invalidateQueries(
+            itemKeys.single(id).publishedInformation,
+          );
+          const currentMemberId = queryClient.getQueryData<CompleteMember>(
+            memberKeys.current().content,
+          )?.id;
           if (currentMemberId) {
             queryClient.invalidateQueries(
-              buildPublishedItemsForMemberKey(currentMemberId),
+              itemKeys.published().byMember(currentMemberId),
             );
           }
-          queryClient.invalidateQueries(buildPublishedItemsKey());
+          queryClient.invalidateQueries(itemKeys.published().all);
         },
       },
     );

--- a/src/mutations/itemTag.test.ts
+++ b/src/mutations/itemTag.test.ts
@@ -13,7 +13,7 @@ import { act } from 'react-test-renderer';
 import { ITEM_TAGS, UNAUTHORIZED_RESPONSE } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildDeleteItemTagRoute, buildPostItemTagRoute } from '../api/routes';
-import { itemTagsKeys } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -33,7 +33,7 @@ describe('Item Tag Mutations', () => {
     const tagType = ItemTagType.Hidden;
     const route = `/${buildPostItemTagRoute({ itemId, type: tagType })}`;
     const mutation = mutations.usePostItemTag;
-    const itemTagKey = itemTagsKeys.singleId(itemId);
+    const itemTagKey = itemKeys.single(itemId).tags;
 
     it('Post item tag', async () => {
       queryClient.setQueryData(itemTagKey, ITEM_TAGS);
@@ -110,7 +110,7 @@ describe('Item Tag Mutations', () => {
     const itemId = item.id;
     const route = `/${buildDeleteItemTagRoute({ itemId, type: tagType })}`;
     const mutation = mutations.useDeleteItemTag;
-    const itemTagKey = itemTagsKeys.singleId(itemId);
+    const itemTagKey = itemKeys.single(itemId).tags;
 
     it('Delete item tag', async () => {
       queryClient.setQueryData(itemTagKey, ITEM_TAGS);

--- a/src/mutations/itemTag.ts
+++ b/src/mutations/itemTag.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { itemTagsKeys } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { deleteItemTagRoutine, postItemTagRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -30,9 +30,9 @@ export default (queryConfig: QueryClientConfig) => {
           notifier?.({ type: postItemTagRoutine.FAILURE, payload: { error } });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(itemTagsKeys.singleId(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).tags);
           // invalidate any "many" query targeting item tags
-          queryClient.invalidateQueries(itemTagsKeys.many());
+          queryClient.invalidateQueries(itemKeys.allMany());
         },
       },
     );
@@ -45,7 +45,7 @@ export default (queryConfig: QueryClientConfig) => {
         Api.deleteItemTag(payload, queryConfig),
       {
         onMutate: async ({ itemId, type }) => {
-          const itemTagKey = itemTagsKeys.singleId(itemId);
+          const itemTagKey = itemKeys.single(itemId).tags;
           await queryClient.cancelQueries(itemTagKey);
 
           // Snapshot the previous value
@@ -70,7 +70,7 @@ export default (queryConfig: QueryClientConfig) => {
           // await queryClient.invalidateQueries(DATA_KEYS.itemTagsKeys.many());
         },
         onError: (error: Error, { itemId }, context) => {
-          const itemKey = itemTagsKeys.singleId(itemId);
+          const itemKey = itemKeys.single(itemId).tags;
           queryClient.setQueryData(itemKey, context?.itemTags);
           notifier?.({
             type: deleteItemTagRoutine.FAILURE,
@@ -78,9 +78,9 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(itemTagsKeys.singleId(itemId));
+          queryClient.invalidateQueries(itemKeys.single(itemId).tags);
           // invalidate any "many" query that contains the id we modified
-          queryClient.invalidateQueries(itemTagsKeys.many());
+          queryClient.invalidateQueries(itemKeys.allMany());
         },
       },
     );

--- a/src/mutations/itemValidation.test.ts
+++ b/src/mutations/itemValidation.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../test/constants';
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { buildPostItemValidationRoute } from '../api/routes';
-import { buildLastItemValidationGroupKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { postItemValidationRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -28,7 +28,7 @@ describe('Item Validation Mutations', () => {
     const itemId = 'item-id';
     const route = `/${buildPostItemValidationRoute(itemId)}`;
     const mutation = mutations.usePostItemValidation;
-    const key = buildLastItemValidationGroupKey(itemId);
+    const key = itemKeys.single(itemId).validation;
 
     it('Post item validation', async () => {
       queryClient.setQueryData(key, ITEM_VALIDATION_GROUP);
@@ -48,7 +48,7 @@ describe('Item Validation Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate({
+        mockedMutation.mutate({
           itemId,
         });
         await waitForMutation();
@@ -76,7 +76,7 @@ describe('Item Validation Mutations', () => {
       });
 
       await act(async () => {
-        await mockedMutation.mutate({ itemId });
+        mockedMutation.mutate({ itemId });
         await waitForMutation();
       });
 

--- a/src/mutations/itemValidation.ts
+++ b/src/mutations/itemValidation.ts
@@ -3,7 +3,7 @@ import { UUID } from '@graasp/sdk';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { buildLastItemValidationGroupKey } from '../config/keys';
+import { itemKeys } from '../config/keys';
 import { postItemValidationRoutine } from '../routines';
 import { QueryClientConfig } from '../types';
 
@@ -28,9 +28,7 @@ export default (queryConfig: QueryClientConfig) => {
           });
         },
         onSettled: (_data, _error, { itemId }) => {
-          queryClient.invalidateQueries(
-            buildLastItemValidationGroupKey(itemId),
-          );
+          queryClient.invalidateQueries(itemKeys.single(itemId).validation);
         },
       },
     );

--- a/src/mutations/member.test.ts
+++ b/src/mutations/member.test.ts
@@ -22,7 +22,7 @@ import {
   buildPatchMember,
   buildUploadAvatarRoute,
 } from '../api/routes';
-import { CURRENT_MEMBER_KEY, buildAvatarKey } from '../config/keys';
+import { memberKeys } from '../config/keys';
 import { uploadAvatarRoutine } from '../routines';
 
 const mockedNotifier = jest.fn();
@@ -42,7 +42,7 @@ describe('Member Mutations', () => {
     it(`Successfully sign out`, async () => {
       const endpoints = [{ route, response: OK_RESPONSE }];
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, MemberFactory());
+      queryClient.setQueryData(memberKeys.current().content, MemberFactory());
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -56,13 +56,15 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toEqual(undefined);
+      expect(queryClient.getQueryData(memberKeys.current().content)).toEqual(
+        undefined,
+      );
     });
 
     it(`Unauthorized`, async () => {
       // set random data in cache
       const member = MemberFactory();
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, member);
+      queryClient.setQueryData(memberKeys.current().content, member);
       const endpoints = [
         {
           method: HttpMethod.GET,
@@ -83,9 +85,9 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toMatchObject(
-        member,
-      );
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toMatchObject(member);
     });
   });
 
@@ -107,7 +109,7 @@ describe('Member Mutations', () => {
         },
       ];
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, MemberFactory());
+      queryClient.setQueryData(memberKeys.current().content, MemberFactory());
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -121,13 +123,15 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toEqual(undefined);
+      expect(queryClient.getQueryData(memberKeys.current().content)).toEqual(
+        undefined,
+      );
     });
 
     it(`Unauthorized`, async () => {
       // set random data in cache
       const member = MemberFactory();
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, member);
+      queryClient.setQueryData(memberKeys.current().content, member);
       const endpoints = [
         {
           method: HttpMethod.GET,
@@ -148,9 +152,9 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      expect(queryClient.getQueryData(CURRENT_MEMBER_KEY)).toMatchObject(
-        member,
-      );
+      expect(
+        queryClient.getQueryData(memberKeys.current().content),
+      ).toMatchObject(member);
     });
   });
 
@@ -164,7 +168,7 @@ describe('Member Mutations', () => {
     it(`Successfully edit member id = ${id}`, async () => {
       const response = { ...member, name: newMember.name };
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, member);
+      queryClient.setQueryData(memberKeys.current().content, member);
       const endpoints = [
         {
           response,
@@ -184,14 +188,15 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      const newData =
-        queryClient.getQueryData<CompleteMember>(CURRENT_MEMBER_KEY);
+      const newData = queryClient.getQueryData<CompleteMember>(
+        memberKeys.current().content,
+      );
       expect(newData).toMatchObject(response);
     });
 
     it(`Unauthorized`, async () => {
       // set random data in cache
-      queryClient.setQueryData(CURRENT_MEMBER_KEY, member);
+      queryClient.setQueryData(memberKeys.current().content, member);
       const endpoints = [
         {
           response: UNAUTHORIZED_RESPONSE,
@@ -212,8 +217,9 @@ describe('Member Mutations', () => {
       });
 
       // verify cache keys
-      const oldData =
-        queryClient.getQueryData<CompleteMember>(CURRENT_MEMBER_KEY);
+      const oldData = queryClient.getQueryData<CompleteMember>(
+        memberKeys.current().content,
+      );
       expect(oldData).toMatchObject(member);
     });
   });
@@ -229,7 +235,7 @@ describe('Member Mutations', () => {
 
       // set data in cache
       Object.values(ThumbnailSize).forEach((size) => {
-        const key = buildAvatarKey({ id, size, replyUrl });
+        const key = memberKeys.single(id).avatar({ size, replyUrl });
         queryClient.setQueryData(key, Math.random());
       });
 
@@ -257,7 +263,7 @@ describe('Member Mutations', () => {
       // verify member is still available
       // in real cases, the path should be different
       for (const size of Object.values(ThumbnailSize)) {
-        const key = buildAvatarKey({ id, size, replyUrl });
+        const key = memberKeys.single(id).avatar({ size, replyUrl });
         const state = queryClient.getQueryState(key);
         expect(state?.isInvalidated).toBeTruthy();
       }
@@ -271,7 +277,7 @@ describe('Member Mutations', () => {
       const route = `/${buildUploadAvatarRoute()}`;
       // set data in cache
       Object.values(ThumbnailSize).forEach((size) => {
-        const key = buildAvatarKey({ id, size, replyUrl });
+        const key = memberKeys.single(id).avatar({ size, replyUrl });
         queryClient.setQueryData(key, Math.random());
       });
 
@@ -300,7 +306,7 @@ describe('Member Mutations', () => {
       // verify member is still available
       // in real cases, the path should be different
       for (const size of Object.values(ThumbnailSize)) {
-        const key = buildAvatarKey({ id, size, replyUrl });
+        const key = memberKeys.single(id).avatar({ size, replyUrl });
         const state = queryClient.getQueryState(key);
         expect(state?.isInvalidated).toBeTruthy();
       }

--- a/src/mutations/membership.test.ts
+++ b/src/mutations/membership.test.ts
@@ -35,8 +35,8 @@ import {
 import {
   OWN_ITEMS_KEY,
   buildItemInvitationsKey,
-  buildItemKey,
   buildItemMembershipsKey,
+  itemKeys,
 } from '../config/keys';
 import {
   deleteItemMembershipRoutine,
@@ -80,7 +80,7 @@ describe('Membership Mutations', () => {
 
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -126,7 +126,7 @@ describe('Membership Mutations', () => {
 
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -324,7 +324,7 @@ describe('Membership Mutations', () => {
     it('Successfully share item with all emails', async () => {
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -384,7 +384,7 @@ describe('Membership Mutations', () => {
     it('Mixed return values for sharing item with many emails', async () => {
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -456,7 +456,7 @@ describe('Membership Mutations', () => {
     it('Unauthorized to search members', async () => {
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -507,7 +507,7 @@ describe('Membership Mutations', () => {
     it('Unauthorized to post memberships', async () => {
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?
@@ -567,7 +567,7 @@ describe('Membership Mutations', () => {
     it('Unauthorized to post invitations', async () => {
       // set data in cache
       items.forEach((i) => {
-        const itemKey = buildItemKey(i.id);
+        const itemKey = itemKeys.single(i.id).content;
         queryClient.setQueryData(itemKey, i);
       });
       // todo: change to Accessible ?

--- a/src/mutations/plan.ts
+++ b/src/mutations/plan.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { CURRENT_CUSTOMER_KEY, OWN_PLAN_KEY } from '../config/keys';
+import { CURRENT_CUSTOMER_KEY, memberKeys } from '../config/keys';
 import {
   changePlanRoutine,
   createSetupIntentRoutine,
@@ -25,7 +25,7 @@ export default (queryConfig: QueryClientConfig) => {
           notifier?.({ type: changePlanRoutine.FAILURE, payload: { error } });
         },
         onSettled: () => {
-          queryClient.invalidateQueries(OWN_PLAN_KEY);
+          queryClient.invalidateQueries(memberKeys.current().subscription);
         },
       },
     );

--- a/src/mutations/publicProfile.test.ts
+++ b/src/mutations/publicProfile.test.ts
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 import { mockMutation, setUpTest, waitForMutation } from '../../test/utils';
 import { MEMBERS_ROUTE, PUBLIC_PROFILE_ROUTE } from '../api/routes';
-import { OWN_PUBLIC_PROFILE_KEY } from '../config/keys';
+import { memberKeys } from '../config/keys';
 
 const mockedNotifier = jest.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -32,7 +32,7 @@ describe('Public Profile Mutations', () => {
       const route = `/${MEMBERS_ROUTE}/${PUBLIC_PROFILE_ROUTE}`;
       const response = { ...newProfile, id: 'someid', member: MemberFactory() };
 
-      queryClient.setQueryData(OWN_PUBLIC_PROFILE_KEY, response);
+      queryClient.setQueryData(memberKeys.current().profile, response);
 
       const endpoints = [
         {
@@ -53,9 +53,9 @@ describe('Public Profile Mutations', () => {
         await waitForMutation();
       });
 
-      expect(queryClient.getQueryState(OWN_PUBLIC_PROFILE_KEY)?.data).toEqual(
-        response,
-      );
+      expect(
+        queryClient.getQueryState(memberKeys.current().profile)?.data,
+      ).toEqual(response);
     });
   });
 
@@ -79,7 +79,7 @@ describe('Public Profile Mutations', () => {
           route,
         },
       ];
-      queryClient.setQueryData(OWN_PUBLIC_PROFILE_KEY, result);
+      queryClient.setQueryData(memberKeys.current().profile, result);
 
       const mockedMutation = await mockMutation({
         endpoints,
@@ -92,10 +92,12 @@ describe('Public Profile Mutations', () => {
         await waitForMutation();
       });
 
-      expect(queryClient.getQueryState(OWN_PUBLIC_PROFILE_KEY)?.data).toEqual(
+      expect(
+        queryClient.getQueryState(memberKeys.current().profile)?.data,
+      ).toEqual(result);
+      expect(queryClient.getQueryData(memberKeys.current().profile)).toEqual(
         result,
       );
-      expect(queryClient.getQueryData(OWN_PUBLIC_PROFILE_KEY)).toEqual(result);
     });
   });
 });

--- a/src/mutations/shortLink.ts
+++ b/src/mutations/shortLink.ts
@@ -4,7 +4,7 @@ import { SUCCESS_MESSAGES } from '@graasp/translations';
 import { useMutation, useQueryClient } from 'react-query';
 
 import * as Api from '../api';
-import { buildShortLinkKey, buildShortLinksItemKey } from '../config/keys';
+import { buildShortLinkKey, itemKeys } from '../config/keys';
 import {
   createShortLinkRoutine,
   deleteShortLinkRoutine,
@@ -27,7 +27,7 @@ export default (queryConfig: QueryClientConfig) => {
             payload: { message: SUCCESS_MESSAGES.CREATE_SHORT_LINK },
           });
           queryClient.invalidateQueries(
-            buildShortLinksItemKey(variables.itemId),
+            itemKeys.single(variables.itemId).shortLinks,
           );
           queryClient.invalidateQueries(buildShortLinkKey(variables.alias));
         },
@@ -57,7 +57,9 @@ export default (queryConfig: QueryClientConfig) => {
             type: patchShortLinkRoutine.SUCCESS,
             payload: { message: SUCCESS_MESSAGES.EDIT_SHORT_LINK },
           });
-          queryClient.invalidateQueries(buildShortLinksItemKey(data.item.id));
+          queryClient.invalidateQueries(
+            itemKeys.single(data.item.id).shortLinks,
+          );
           queryClient.invalidateQueries(buildShortLinkKey(data.alias));
         },
         onError: (error: Error) => {
@@ -80,7 +82,9 @@ export default (queryConfig: QueryClientConfig) => {
             type: deleteShortLinkRoutine.SUCCESS,
             payload: { message: SUCCESS_MESSAGES.DELETE_SHORT_LINK },
           });
-          queryClient.invalidateQueries(buildShortLinksItemKey(data.item.id));
+          queryClient.invalidateQueries(
+            itemKeys.single(data.item.id).shortLinks,
+          );
           queryClient.invalidateQueries(buildShortLinkKey(data.alias));
         },
         onError: (error: Error) => {


### PR DESCRIPTION
The idea is to gather keys related to items together, so it's easier to invalidate its data altogether.

Example:
```js

export const buildItemKeys = {
  all: [ITEMS_CONTEXT],

  // single item
  singleItem: (id?: UUID) => ({
    all: [ITEMS_CONTEXT, id],

    // general data
    data: [ITEMS_CONTEXT, id, 'data'],

    // children
    allChildren: [ITEMS_CONTEXT, id, 'children'],
    children: (types?: UnionOfConst<typeof ItemType>[]) => [
      ITEMS_CONTEXT,
      id,
      'children',
      types,
    ],
    // todo: add page and filtering options
    singlePageChildren: [ITEMS_CONTEXT, id, 'children', 'paginated'],

    // descendants
    descendants: ...
    
    },

    manyItems: {
         all: ...,
         data: ...,

         allChildren: ...
         children: ...
....
}
```