### PR TITLE
feat: invalidate queries when move

### DIFF
--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -1,12 +1,6 @@
-import {
-  AggregateBy,
-  Category,
-  ItemType,
-  UUID,
-  UnionOfConst,
-} from '@graasp/sdk';
+import { AggregateBy, Category, UUID } from '@graasp/sdk';
 
-import { ItemSearchParams } from '../api/routes';
+import { ItemChildrenParams, ItemSearchParams } from '../api/routes';
 import { PaginationParams } from '../types';
 import { AggregateActionsArgs } from '../utils/action';
 import { hashItemsIds } from '../utils/item';
@@ -34,19 +28,19 @@ export const buildItemsKey = (ids: UUID[]) => [
   ITEMS_CONTEXT,
   hashItemsIds(ids),
 ];
-export const buildItemChildrenKey = (
-  id: UUID | undefined,
-  types?: UnionOfConst<typeof ItemType>[],
-) => [ITEMS_CONTEXT, 'children', id, types];
+export const buildItemChildrenKeys = (id: UUID | undefined) => ({
+  all: [ITEMS_CONTEXT, id, 'children'],
+  single: (params?: ItemChildrenParams) => [
+    ITEMS_CONTEXT,
+    id,
+    'children',
+    params,
+  ],
+});
 export const buildItemPaginatedChildrenKey = (id?: UUID) => [
   ITEMS_CONTEXT,
   'childrenPaginated',
   id,
-];
-export const buildItemsChildrenKey = (ids: UUID[]) => [
-  ITEMS_CONTEXT,
-  'children',
-  hashItemsIds(ids),
 ];
 export const buildItemDescendantsKey = (id?: UUID) => [
   ITEMS_CONTEXT,
@@ -78,7 +72,7 @@ const MENTIONS_CONTEXT = 'mentions';
 export const buildMentionKey = () => [MENTIONS_CONTEXT];
 
 export const getKeyForParentId = (parentId?: UUID | null) =>
-  parentId ? buildItemChildrenKey(parentId) : accessibleItemsKeys.all;
+  parentId ? buildItemChildrenKeys(parentId).all : accessibleItemsKeys.all;
 
 export const buildItemMembershipsKey = (id?: UUID) => [
   ITEMS_CONTEXT,
@@ -315,8 +309,7 @@ export const DATA_KEYS = {
   APPS_KEY,
   buildItemKey,
   buildItemsKey,
-  buildItemChildrenKey,
-  buildItemsChildrenKey,
+  buildItemChildrenKeys,
   CURRENT_MEMBER_KEY,
   buildMemberKey,
   buildMembersKey,

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -26,17 +26,16 @@ export const buildShortLinksItemKey = (id: UUID) => [
 export const buildItemKey = (id?: UUID) => [ITEMS_CONTEXT, id];
 export const buildItemsKey = (ids: UUID[]) => [
   ITEMS_CONTEXT,
+  'many',
   hashItemsIds(ids),
 ];
-export const buildItemChildrenKeys = (id: UUID | undefined) => ({
-  all: [ITEMS_CONTEXT, id, 'children'],
-  single: (params?: ItemChildrenParams) => [
-    ITEMS_CONTEXT,
-    id,
-    'children',
+export const buildItemChildrenKeys = {
+  all: (id: UUID | undefined) => [ITEMS_CONTEXT, id, 'children'],
+  single: (id: UUID | undefined, params?: ItemChildrenParams) => [
+    ...buildItemChildrenKeys.all(id),
     params,
   ],
-});
+};
 export const buildItemPaginatedChildrenKey = (id?: UUID) => [
   ITEMS_CONTEXT,
   'childrenPaginated',
@@ -72,7 +71,7 @@ const MENTIONS_CONTEXT = 'mentions';
 export const buildMentionKey = () => [MENTIONS_CONTEXT];
 
 export const getKeyForParentId = (parentId?: UUID | null) =>
-  parentId ? buildItemChildrenKeys(parentId).all : accessibleItemsKeys.all;
+  parentId ? buildItemChildrenKeys.all(parentId) : accessibleItemsKeys.all;
 
 export const buildItemMembershipsKey = (id?: UUID) => [
   ITEMS_CONTEXT,

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -40,7 +40,7 @@ import {
   SHARED_ITEMS_KEY,
   accessibleItemsKeys,
   buildFileContentKey,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemKey,
   buildItemParentsKey,
   buildItemThumbnailKey,
@@ -101,7 +101,7 @@ describe('Items Hooks', () => {
     const params = { ordered: true };
     const route = `/${buildGetChildrenRoute(id, params)}`;
     const response = ITEMS;
-    const key = buildItemChildrenKey(id);
+    const key = buildItemChildrenKeys(id).all;
 
     it(`Receive children of item by id`, async () => {
       const hook = () => hooks.useChildren(id);
@@ -209,7 +209,9 @@ describe('Items Hooks', () => {
       expect(data).toBeFalsy();
       expect(isError).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(buildItemChildrenKey(id))).toBeFalsy();
+      expect(
+        queryClient.getQueryData(buildItemChildrenKeys(id).all),
+      ).toBeFalsy();
     });
   });
 

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -101,7 +101,7 @@ describe('Items Hooks', () => {
     const params = { ordered: true };
     const route = `/${buildGetChildrenRoute(id, params)}`;
     const response = ITEMS;
-    const key = buildItemChildrenKeys(id).single();
+    const key = buildItemChildrenKeys.single(id, { ordered: true });
 
     it(`Receive children of item by id`, async () => {
       const hook = () => hooks.useChildren(id);
@@ -115,9 +115,7 @@ describe('Items Hooks', () => {
       expect(data).toMatchObject(response);
       expect(isSuccess).toBeTruthy();
       // verify cache keys
-      expect(
-        queryClient.getQueryData(buildItemChildrenKeys(id).single()),
-      ).toEqual(response);
+      expect(queryClient.getQueryData(key)).toEqual(response);
       for (const item of response) {
         expect(queryClient.getQueryData(buildItemKey(item.id))).toEqual(item);
       }
@@ -175,7 +173,7 @@ describe('Items Hooks', () => {
       const unorderedParams = {
         ordered: false,
       };
-      const unorderedKey = buildItemChildrenKeys(id).single(unorderedParams);
+      const unorderedKey = buildItemChildrenKeys.single(id, unorderedParams);
       const unorderedRoute = `/${buildGetChildrenRoute(id, unorderedParams)}`;
       const hook = () => hooks.useChildren(id, unorderedParams);
       const endpoints = [{ route: unorderedRoute, response }];
@@ -215,7 +213,7 @@ describe('Items Hooks', () => {
       expect(isError).toBeTruthy();
       // verify cache keys
       expect(
-        queryClient.getQueryData(buildItemChildrenKeys(id).all),
+        queryClient.getQueryData(buildItemChildrenKeys.all(id)),
       ).toBeFalsy();
     });
   });

--- a/src/hooks/item.test.ts
+++ b/src/hooks/item.test.ts
@@ -101,7 +101,7 @@ describe('Items Hooks', () => {
     const params = { ordered: true };
     const route = `/${buildGetChildrenRoute(id, params)}`;
     const response = ITEMS;
-    const key = buildItemChildrenKeys(id).all;
+    const key = buildItemChildrenKeys(id).single();
 
     it(`Receive children of item by id`, async () => {
       const hook = () => hooks.useChildren(id);
@@ -115,7 +115,9 @@ describe('Items Hooks', () => {
       expect(data).toMatchObject(response);
       expect(isSuccess).toBeTruthy();
       // verify cache keys
-      expect(queryClient.getQueryData(key)).toEqual(response);
+      expect(
+        queryClient.getQueryData(buildItemChildrenKeys(id).single()),
+      ).toEqual(response);
       for (const item of response) {
         expect(queryClient.getQueryData(buildItemKey(item.id))).toEqual(item);
       }
@@ -170,10 +172,12 @@ describe('Items Hooks', () => {
     });
 
     it(`ordered=false fetch children`, async () => {
-      const unorderedRoute = `/${buildGetChildrenRoute(id, {
+      const unorderedParams = {
         ordered: false,
-      })}`;
-      const hook = () => hooks.useChildren(id, { ordered: false });
+      };
+      const unorderedKey = buildItemChildrenKeys(id).single(unorderedParams);
+      const unorderedRoute = `/${buildGetChildrenRoute(id, unorderedParams)}`;
+      const hook = () => hooks.useChildren(id, unorderedParams);
       const endpoints = [{ route: unorderedRoute, response }];
       const { data, isSuccess } = await mockHook({
         endpoints,
@@ -183,8 +187,9 @@ describe('Items Hooks', () => {
 
       expect(isSuccess).toBeTruthy();
       expect(data).toMatchObject(response);
+
       // verify cache keys
-      expect(queryClient.getQueryData(key)).toMatchObject(response);
+      expect(queryClient.getQueryData(unorderedKey)).toMatchObject(response);
       for (const item of response) {
         expect(queryClient.getQueryData(buildItemKey(item.id))).toMatchObject(
           item,

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -149,7 +149,10 @@ export default (
       const queryClient = useQueryClient();
 
       return useQuery({
-        queryKey: buildItemChildrenKeys(id).single(params),
+        queryKey: buildItemChildrenKeys.single(id, {
+          ...params,
+          ordered,
+        }),
         queryFn: () => {
           if (!id) {
             throw new UndefinedArgument();

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -33,7 +33,7 @@ import {
   accessibleItemsKeys,
   buildEtherpadKey,
   buildFileContentKey,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemDescendantsKey,
   buildItemKey,
   buildItemPaginatedChildrenKey,
@@ -149,7 +149,7 @@ export default (
       const queryClient = useQueryClient();
 
       return useQuery({
-        queryKey: buildItemChildrenKey(id, params?.types),
+        queryKey: buildItemChildrenKeys(id).single(params),
         queryFn: () => {
           if (!id) {
             throw new UndefinedArgument();

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -41,7 +41,7 @@ import {
   OWN_ITEMS_KEY,
   RECYCLED_ITEMS_DATA_KEY,
   accessibleItemsKeys,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemKey,
   buildItemThumbnailKey,
   getKeyForParentId,
@@ -304,7 +304,7 @@ describe('Items Mutations', () => {
         // these are dummy ids, in reality they should be UUIDs
         extra: { folder: { childrenOrder: ['1', '2'] } },
       };
-      const childrenKey = buildItemChildrenKey(editedItem.id);
+      const childrenKey = buildItemChildrenKeys(editedItem.id).all;
       queryClient.setQueryData(childrenKey, [ITEMS[1]]);
       queryClient.setQueryData(editedItemKey, editedItem);
 
@@ -755,7 +755,7 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(accessibleItemsKeys.all, ITEMS);
-      queryClient.setQueryData(buildItemChildrenKey(id), ITEMS);
+      queryClient.setQueryData(buildItemChildrenKeys(id).all, ITEMS);
 
       const mockedMutation = await mockMutation({
         endpoints: [],
@@ -769,7 +769,7 @@ describe('Items Mutations', () => {
       });
 
       // check memberships invalidation
-      const data = queryClient.getQueryState(buildItemChildrenKey(id));
+      const data = queryClient.getQueryState(buildItemChildrenKeys(id).all);
       expect(data?.isInvalidated).toBeTruthy();
 
       // check notification trigger
@@ -786,7 +786,7 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(accessibleItemsKeys.all, ITEMS);
-      queryClient.setQueryData(buildItemChildrenKey(id), ITEMS);
+      queryClient.setQueryData(buildItemChildrenKeys(id).all, ITEMS);
 
       const mockedMutation = await mockMutation({
         endpoints: [],
@@ -802,7 +802,7 @@ describe('Items Mutations', () => {
       });
 
       // check memberships invalidation
-      const data = queryClient.getQueryState(buildItemChildrenKey(id));
+      const data = queryClient.getQueryState(buildItemChildrenKeys(id).all);
       expect(data?.isInvalidated).toBeTruthy();
 
       // check notification trigger

--- a/src/mutations/item.test.ts
+++ b/src/mutations/item.test.ts
@@ -304,7 +304,7 @@ describe('Items Mutations', () => {
         // these are dummy ids, in reality they should be UUIDs
         extra: { folder: { childrenOrder: ['1', '2'] } },
       };
-      const childrenKey = buildItemChildrenKeys(editedItem.id).all;
+      const childrenKey = buildItemChildrenKeys.all(editedItem.id);
       queryClient.setQueryData(childrenKey, [ITEMS[1]]);
       queryClient.setQueryData(editedItemKey, editedItem);
 
@@ -755,7 +755,7 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(accessibleItemsKeys.all, ITEMS);
-      queryClient.setQueryData(buildItemChildrenKeys(id).all, ITEMS);
+      queryClient.setQueryData(buildItemChildrenKeys.all(id), ITEMS);
 
       const mockedMutation = await mockMutation({
         endpoints: [],
@@ -769,7 +769,7 @@ describe('Items Mutations', () => {
       });
 
       // check memberships invalidation
-      const data = queryClient.getQueryState(buildItemChildrenKeys(id).all);
+      const data = queryClient.getQueryState(buildItemChildrenKeys.all(id));
       expect(data?.isInvalidated).toBeTruthy();
 
       // check notification trigger
@@ -786,7 +786,7 @@ describe('Items Mutations', () => {
         queryClient.setQueryData(itemKey, item);
       });
       queryClient.setQueryData(accessibleItemsKeys.all, ITEMS);
-      queryClient.setQueryData(buildItemChildrenKeys(id).all, ITEMS);
+      queryClient.setQueryData(buildItemChildrenKeys.all(id), ITEMS);
 
       const mockedMutation = await mockMutation({
         endpoints: [],
@@ -802,7 +802,7 @@ describe('Items Mutations', () => {
       });
 
       // check memberships invalidation
-      const data = queryClient.getQueryState(buildItemChildrenKeys(id).all);
+      const data = queryClient.getQueryState(buildItemChildrenKeys.all(id));
       expect(data?.isInvalidated).toBeTruthy();
 
       // check notification trigger

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -79,7 +79,7 @@ export default (queryConfig: QueryClientConfig) => {
     // get parent key
     const childrenKey = !parentId
       ? OWN_ITEMS_KEY
-      : buildItemChildrenKeys(parentId).all;
+      : buildItemChildrenKeys.all(parentId);
     // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
     await queryClient.cancelQueries(childrenKey);
 
@@ -246,7 +246,7 @@ export default (queryConfig: QueryClientConfig) => {
 
           // reorder affect children to change
           if ((extra as FolderItemExtra)?.[ItemType.FOLDER]?.childrenOrder) {
-            queryClient.invalidateQueries(buildItemChildrenKeys(id).all);
+            queryClient.invalidateQueries(buildItemChildrenKeys.all(id));
           }
 
           const itemKey = buildItemKey(id);

--- a/src/mutations/item.ts
+++ b/src/mutations/item.ts
@@ -18,7 +18,7 @@ import {
 import {
   OWN_ITEMS_KEY,
   RECYCLED_ITEMS_DATA_KEY,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemKey,
   getKeyForParentId,
   itemsWithGeolocationKeys,
@@ -79,7 +79,7 @@ export default (queryConfig: QueryClientConfig) => {
     // get parent key
     const childrenKey = !parentId
       ? OWN_ITEMS_KEY
-      : buildItemChildrenKey(parentId);
+      : buildItemChildrenKeys(parentId).all;
     // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
     await queryClient.cancelQueries(childrenKey);
 
@@ -246,7 +246,7 @@ export default (queryConfig: QueryClientConfig) => {
 
           // reorder affect children to change
           if ((extra as FolderItemExtra)?.[ItemType.FOLDER]?.childrenOrder) {
-            queryClient.invalidateQueries(buildItemChildrenKey(id));
+            queryClient.invalidateQueries(buildItemChildrenKeys(id).all);
           }
 
           const itemKey = buildItemKey(id);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,7 @@
+import { DiscriminatedItem } from '@graasp/sdk';
+
+import { ItemChildrenParams } from '../api/routes';
+
 export const isObject = (value: unknown) =>
   typeof value === 'object' && !Array.isArray(value) && value !== null;
 
@@ -35,3 +39,21 @@ export const paginate = <U>(
       reject(error);
     }
   });
+
+export const shouldBeAddedInCache = ({
+  newItem,
+  params,
+}: {
+  newItem: DiscriminatedItem;
+  params?: ItemChildrenParams;
+}) => {
+  if (!params) {
+    return true;
+  }
+
+  if (params.types && params.types.includes(newItem.type)) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/ws/hooks/item.test.ts
+++ b/src/ws/hooks/item.test.ts
@@ -87,7 +87,7 @@ describe('Ws Item Hooks', () => {
     // we need to use a different id for the channel to avoid handlers collision
     const parent = ITEMS[1];
     const parentId = parent.id;
-    const childrenKey = buildItemChildrenKeys(parentId).all;
+    const childrenKey = buildItemChildrenKeys.all(parentId);
     const channel = { name: parentId, topic: TOPICS.ITEM };
     const targetItem = ITEMS[2];
     const targetItemKey = buildItemKey(targetItem.id);

--- a/src/ws/hooks/item.test.ts
+++ b/src/ws/hooks/item.test.ts
@@ -10,7 +10,7 @@ import {
   OWN_ITEMS_KEY,
   SHARED_ITEMS_KEY,
   accessibleItemsKeys,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemKey,
 } from '../../config/keys';
 import { KINDS, OPS, TOPICS } from '../constants';
@@ -87,7 +87,7 @@ describe('Ws Item Hooks', () => {
     // we need to use a different id for the channel to avoid handlers collision
     const parent = ITEMS[1];
     const parentId = parent.id;
-    const childrenKey = buildItemChildrenKey(parentId);
+    const childrenKey = buildItemChildrenKeys(parentId).all;
     const channel = { name: parentId, topic: TOPICS.ITEM };
     const targetItem = ITEMS[2];
     const targetItemKey = buildItemKey(targetItem.id);

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -19,7 +19,7 @@ import {
   RECYCLED_ITEMS_KEY,
   SHARED_ITEMS_KEY,
   accessibleItemsKeys,
-  buildItemChildrenKey,
+  buildItemChildrenKeys,
   buildItemKey,
 } from '../../config/keys';
 import {
@@ -181,12 +181,15 @@ export const configureWsItemHooks = (
       }
 
       const channel: Channel = { name: parentId, topic: TOPICS.ITEM };
-      const parentChildrenKey = buildItemChildrenKey(parentId);
+      const parentChildrenKey = buildItemChildrenKeys(parentId).all;
 
       const handler = (event: ItemEvent) => {
         if (event.kind === KINDS.CHILD) {
           const current =
             queryClient.getQueryData<DiscriminatedItem[]>(parentChildrenKey);
+
+          // TODO: check if we have to invalidate queries or not
+          queryClient.invalidateQueries(parentChildrenKey);
 
           if (current) {
             const { item } = event;

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -185,44 +185,46 @@ export const configureWsItemHooks = (
 
       const handler = (event: ItemEvent) => {
         if (event.kind === KINDS.CHILD) {
-          const current =
-            queryClient.getQueryData<DiscriminatedItem[]>(parentChildrenKey);
+          // const current =
+          //   queryClient.getQueryData<DiscriminatedItem[]>(parentChildrenKey);
 
           // TODO: check if we have to invalidate queries or not
+          const { item } = event;
           queryClient.invalidateQueries(parentChildrenKey);
+          queryClient.invalidateQueries(buildItemKey(item.id));
 
-          if (current) {
-            const { item } = event;
-            let mutation;
+          // if (current) {
+          //   const { item } = event;
+          //   let mutation;
 
-            switch (event.op) {
-              case OPS.CREATE: {
-                if (!current.find((i) => i.id === item.id)) {
-                  mutation = [...current, item];
-                  queryClient.setQueryData(parentChildrenKey, mutation);
-                  queryClient.setQueryData(buildItemKey(item.id), item);
-                }
-                break;
-              }
-              case OPS.UPDATE: {
-                // replace value if it exists
-                mutation = current.map((i) => (i.id === item.id ? item : i));
-                queryClient.setQueryData(parentChildrenKey, mutation);
-                queryClient.setQueryData(buildItemKey(item.id), item);
+          //   switch (event.op) {
+          //     case OPS.CREATE: {
+          //       if (!current.find((i) => i.id === item.id)) {
+          //         mutation = [...current, item];
+          //         queryClient.setQueryData(parentChildrenKey, mutation);
+          //         queryClient.setQueryData(buildItemKey(item.id), item);
+          //       }
+          //       break;
+          //     }
+          //     case OPS.UPDATE: {
+          //       // replace value if it exists
+          //       mutation = current.map((i) => (i.id === item.id ? item : i));
+          //       queryClient.setQueryData(parentChildrenKey, mutation);
+          //       queryClient.setQueryData(buildItemKey(item.id), item);
 
-                break;
-              }
-              case OPS.DELETE: {
-                mutation = current.filter((i) => i.id !== item.id);
-                queryClient.setQueryData(parentChildrenKey, mutation);
-                // question: reset item key
-                break;
-              }
-              default:
-                console.error('unhandled event for useChildrenUpdates');
-                break;
-            }
-          }
+          //       break;
+          //     }
+          //     case OPS.DELETE: {
+          //       mutation = current.filter((i) => i.id !== item.id);
+          //       queryClient.setQueryData(parentChildrenKey, mutation);
+          //       // question: reset item key
+          //       break;
+          //     }
+          //     default:
+          //       console.error('unhandled event for useChildrenUpdates');
+          //       break;
+          //   }
+          // }
         }
       };
 


### PR DESCRIPTION
The main idea here is to:
- Update the cache correctly for the new useChildren keys.
- Invalidates correctly the queries when the ws notifications are received at the end of the transaction (should update the backend).