### PR TITLE
fix: make graasp deps peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,11 @@
     "Alexandre Chau"
   ],
   "dependencies": {
-    "@graasp/sdk": "3.8.3",
-    "@graasp/translations": "1.23.0",
     "axios": "0.27.2",
     "crypto-js": "4.2.0",
-    "date-fns": "3.3.1",
     "http-status-codes": "2.3.0",
     "qs": "6.11.2",
-    "react-query": "3.39.3",
-    "uuid": "9.0.1"
+    "react-query": "3.39.3"
   },
   "devDependencies": {
     "@babel/core": "7.23.9",
@@ -33,6 +29,8 @@
     "@babel/preset-typescript": "7.23.3",
     "@commitlint/cli": "18.6.0",
     "@commitlint/config-conventional": "18.6.0",
+    "@graasp/sdk": "3.8.3",
+    "@graasp/translations": "1.23.0",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "14.2.1",
@@ -50,6 +48,7 @@
     "@typescript-eslint/eslint-plugin": "7.0.1",
     "@typescript-eslint/parser": "7.0.1",
     "babel-jest": "29.7.0",
+    "date-fns": "3.3.1",
     "env-cmd": "10.1.0",
     "eslint": "8.56.0",
     "eslint-config-airbnb": "19.0.4",
@@ -71,9 +70,12 @@
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
     "tsc-alias": "1.8.8",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "uuid": "9.0.1"
   },
   "peerDependencies": {
+    "@graasp/sdk": "^3.8.3",
+    "@graasp/translations": "^1.23.0",
     "react": "^17.0.0 || ^18.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,6 +1869,8 @@ __metadata:
     typescript: "npm:5.3.3"
     uuid: "npm:9.0.1"
   peerDependencies:
+    "@graasp/sdk": ^3.8.3
+    "@graasp/translations": ^1.23.0
     react: ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This change allows to remove the duplication of `@graasp/sdk` between query-client node-modules and the version that will be used in builder for example. 

In practice this means a reduction from **12MB** to **9MB** with this PR alone when used in builder. (yes sdk is faaat, this will be fixed in a next PR)