### PR TITLE
feat: invalidate all children keys after useChildrenUpdates

### DIFF
--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -51,7 +51,7 @@ export const itemKeys = {
       allChildren,
 
       // itemKeys.single(id).children([one, two])
-      children: (types?: UnionOfConst<typeof ItemType>[]) =>
+      children: (types: UnionOfConst<typeof ItemType>[] = []) =>
         [...allChildren, types] as const,
 
       // todo: add page and filtering options

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -220,6 +220,12 @@ export const configureWsItemHooks = (
                 console.error('unhandled event for useChildrenUpdates');
                 break;
             }
+
+            // TODO: when the backend is updated correctly with the web sockets,
+            // it will be possible to remove all the manipulations of the cache.
+            queryClient.invalidateQueries(
+              itemKeys.single(parentId).allChildren,
+            );
           }
         }
       };


### PR DESCRIPTION
- also update children key to have empty array instead of undefined types
- this change avoid to have undefined and [] as keys cache for unfiltered children

this is linked to graasp/graasp#831.