### PR TITLE
feat: export use debounce callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "axios": "1.6.7",
     "crypto-js": "4.2.0",
     "http-status-codes": "2.3.0",
+    "lodash.debounce": "4.0.8",
     "qs": "6.11.2"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@trivago/prettier-plugin-sort-imports": "4.3.0",
     "@types/crypto-js": "4.2.2",
     "@types/jsdom": "21.1.6",
+    "@types/lodash.debounce": "^4",
     "@types/qs": "6.9.11",
     "@types/react": "18.2.60",
     "@types/react-dom": "18.2.19",

--- a/src/hooks/item.ts
+++ b/src/hooks/item.ts
@@ -31,7 +31,7 @@ import {
 import { PaginationParams, QueryClientConfig } from '../types.js';
 import { paginate } from '../utils/util.js';
 import { configureWsItemHooks } from '../ws/index.js';
-import useDebounce from './useDebounce.js';
+import { useDebounce } from './useDebounce.js';
 
 export default (
   queryConfig: QueryClientConfig,

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import * as Api from '../api/search.js';
 import { itemKeys } from '../config/keys.js';
 import { QueryClientConfig } from '../types.js';
-import useDebounce from './useDebounce.js';
+import { useDebounce } from './useDebounce.js';
 
 export default (queryConfig: QueryClientConfig) => {
   const { defaultQueryOptions } = queryConfig;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react';
+import debounce from 'lodash.debounce';
+import { useEffect, useMemo, useState } from 'react';
 
+// TODO: define a single debounce hook
+// probably it's more versatile to keep the callback one
+// remove lodash debounce?
 // see https://github.com/tannerlinsley/react-query/issues/293
 // see https://usehooks.com/useDebounce/
-export default function useDebounce<T>(value: T, delay: number) {
+export function useDebounce<T>(value: T, delay: number) {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -25,3 +29,37 @@ export default function useDebounce<T>(value: T, delay: number) {
 
   return debouncedValue;
 }
+
+/**
+ * This custom hooks create a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
+ *
+ * **Warning**: It is important to use useCallback for the callback params to ensure to not end in an infinite loop.
+ *
+ * @param callback The callback function to debounce, returned by a **useCallback**.
+ * @param debounceDelayMS The number of milliseconds to delay.
+ * @returns isDebounced Indicates if the callback is debounced or not.
+ */
+export const useDebounceCallback = (
+  callback: () => void,
+  debounceDelayMS: number,
+): { isDebounced: boolean } => {
+  const [isDebounced, setIsDebounced] = useState<boolean>(false);
+
+  const debounceSetSend = useMemo(() => {
+    setIsDebounced(true);
+    return debounce(() => {
+      callback();
+      setIsDebounced(false);
+    }, debounceDelayMS);
+  }, [callback, debounceDelayMS]);
+
+  // Stop the invocation of the debounced function after unmounting
+  useEffect(() => () => debounceSetSend.cancel(), [debounceSetSend]);
+
+  // Call debounce to minimize calls
+  useEffect(() => debounceSetSend(), [debounceSetSend, callback]);
+
+  return {
+    isDebounced,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,9 @@ export * as routines from './routines/index.js';
 export { DATA_KEYS } from './config/keys.js';
 export { API_ROUTES } from './api/routes.js';
 
+// utils hook
+// todo: avoid to export and include debounce within the hook itself?
+export { useDebounceCallback } from './hooks/useDebounce.js';
+
 export * from './types.js';
 export { MockWebSocket } from './ws/index.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,6 +609,7 @@ __metadata:
     "@trivago/prettier-plugin-sort-imports": "npm:4.3.0"
     "@types/crypto-js": "npm:4.2.2"
     "@types/jsdom": "npm:21.1.6"
+    "@types/lodash.debounce": "npm:^4"
     "@types/qs": "npm:6.9.11"
     "@types/react": "npm:18.2.60"
     "@types/react-dom": "npm:18.2.19"
@@ -632,6 +633,7 @@ __metadata:
     husky: "npm:9.0.11"
     i18next: "npm:23.10.0"
     jsdom: "npm:24.0.0"
+    lodash.debounce: "npm:4.0.8"
     mock-socket: "npm:9.3.1"
     nock: "npm:13.5.4"
     prettier: "npm:3.2.5"
@@ -1124,6 +1126,22 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10/4e5aed58cabb2bbf6f725da13421aa50a49abb6bc17bfab6c31b8774b073fa7b50d557c61f961a09a85f6056151190f8ac95f13f5b48136ba5841f7d4484ec56
+  languageName: node
+  linkType: hard
+
+"@types/lodash.debounce@npm:^4":
+  version: 4.0.9
+  resolution: "@types/lodash.debounce@npm:4.0.9"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10/8183a152e01928e3b97ca773f6ae6038b8695e76493ba8bf6b743ec143948a62294fbc9d49fa4a78b52265b3ba4892ef57534e0c13d04aa0f111671b5a944feb
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.14.202
+  resolution: "@types/lodash@npm:4.14.202"
+  checksum: 10/1bb9760a5b1dda120132c4b987330d67979c95dbc22612678682cd61b00302e190f4207228f3728580059cdab5582362262e3819aea59960c1017bd2b9fb26f6
   languageName: node
   linkType: hard
 
@@ -4153,6 +4171,13 @@ __metadata:
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
   checksum: 10/c301cc379310441dc73cd6cebeb91fb254bea74e6ad3027f9346fc43b4174385153df420ffa521654e502fd34c40ef69ca4e7d40ee7129a99e06f306032bfc65
+  languageName: node
+  linkType: hard
+
+"lodash.debounce@npm:4.0.8":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: 10/cd0b2819786e6e80cb9f5cda26b1a8fc073daaf04e48d4cb462fa4663ec9adb3a5387aa22d7129e48eed1afa05b482e2a6b79bfc99b86886364449500cbb00fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In a later issue we can merge both hooks and avoid exporting them by using them on query client exclusively.