### PR TITLE
feat: add enableNotifications params in some mutations

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,6 +23,7 @@ import configurePublicProfileHooks from './publicProfile.js';
 import configureKeywordSearchHooks from './search.js';
 import configureShortLinkHooks from './shortLink.js';
 import configureSubscriptionHooks from './subscription.js';
+import useDebounce from './useDebounce.js';
 
 export default (
   queryConfig: QueryClientConfig,
@@ -57,5 +58,6 @@ export default (
     ...configureShortLinkHooks(queryConfig),
     ...configureItemGeolocationHooks(queryConfig),
     ...configureEmbeddedLinkHooks(queryConfig),
+    useDebounce,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { API_ROUTES } from './api/routes.js';
 
 export * from './types.js';
 export { MockWebSocket } from './ws/index.js';
+export * from './utils/notifications.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,33 @@ import { Invitation } from '@graasp/sdk';
 
 import { AxiosError, AxiosInstance } from 'axios';
 
-export type Notifier = (e: {
-  type: string;
-  payload?: {
-    error?: Error | AxiosError;
-    message?: string;
-    [key: string]: unknown;
-  };
-}) => void;
+export enum NotificationStatus {
+  INFO = 'info',
+  SUCCESS = 'success',
+  ERROR = 'error',
+}
+export type EnableNotifications =
+  | {
+      [status in NotificationStatus]?: boolean;
+    }
+  | boolean;
+export type EnableNotificationsParam = {
+  enableNotifications: EnableNotifications;
+};
+
+export type NotifierOptions = Partial<EnableNotificationsParam>;
+
+export type Notifier = (
+  e: {
+    type: string;
+    payload?: {
+      error?: Error | AxiosError;
+      message?: string;
+      [key: string]: unknown;
+    };
+  },
+  options?: NotifierOptions,
+) => void;
 
 export type QueryClientConfig = {
   API_HOST: string;

--- a/src/utils/notifications.test.ts
+++ b/src/utils/notifications.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { EnableNotifications, NotificationStatus } from '../types.js';
+import { isNotificationEnabled } from './notifications.js';
+
+describe('isNotificationEnabled', () => {
+  it('returns true for globally enabled notifications', () => {
+    const enabledParam: EnableNotifications = true;
+
+    expect(isNotificationEnabled(enabledParam, NotificationStatus.INFO)).toBe(
+      true,
+    );
+    expect(
+      isNotificationEnabled(enabledParam, NotificationStatus.SUCCESS),
+    ).toBe(true);
+    expect(isNotificationEnabled(enabledParam, NotificationStatus.ERROR)).toBe(
+      true,
+    );
+  });
+
+  it('returns true when undefined', () => {
+    const enabledParam = undefined;
+
+    expect(isNotificationEnabled(enabledParam, NotificationStatus.INFO)).toBe(
+      true,
+    );
+    expect(
+      isNotificationEnabled(enabledParam, NotificationStatus.SUCCESS),
+    ).toBe(true);
+    expect(isNotificationEnabled(enabledParam, NotificationStatus.ERROR)).toBe(
+      true,
+    );
+  });
+
+  it('returns true for specifically enabled notification status', () => {
+    const enabledStatusParam: EnableNotifications = {
+      [NotificationStatus.INFO]: true,
+      [NotificationStatus.SUCCESS]: false,
+      [NotificationStatus.ERROR]: true,
+    };
+
+    expect(
+      isNotificationEnabled(enabledStatusParam, NotificationStatus.INFO),
+    ).toBe(true);
+    expect(
+      isNotificationEnabled(enabledStatusParam, NotificationStatus.SUCCESS),
+    ).toBe(false);
+    expect(
+      isNotificationEnabled(enabledStatusParam, NotificationStatus.ERROR),
+    ).toBe(true);
+  });
+
+  it('returns false for globally disabled notifications', () => {
+    const disabledParam: EnableNotifications = false;
+
+    expect(isNotificationEnabled(disabledParam, NotificationStatus.INFO)).toBe(
+      false,
+    );
+    expect(
+      isNotificationEnabled(disabledParam, NotificationStatus.SUCCESS),
+    ).toBe(false);
+    expect(isNotificationEnabled(disabledParam, NotificationStatus.ERROR)).toBe(
+      false,
+    );
+  });
+
+  it('returns false for missing notification status in specific configuration', () => {
+    const partialParam: EnableNotifications = {
+      [NotificationStatus.INFO]: true,
+    };
+
+    expect(isNotificationEnabled(partialParam, NotificationStatus.INFO)).toBe(
+      true,
+    );
+    expect(
+      isNotificationEnabled(partialParam, NotificationStatus.SUCCESS),
+    ).toBe(false);
+    expect(isNotificationEnabled(partialParam, NotificationStatus.ERROR)).toBe(
+      false,
+    );
+  });
+});

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,24 @@
+import {
+  EnableNotifications,
+  EnableNotificationsParam,
+  NotificationStatus,
+} from '../types.js';
+
+export const DEFAULT_ENABLE_NOTIFICATIONS: EnableNotificationsParam = {
+  enableNotifications: true,
+};
+
+export const isNotificationEnabled = (
+  enableNotifications: EnableNotifications | undefined,
+  notificationStatus: NotificationStatus,
+) => {
+  if (enableNotifications === undefined) {
+    return true;
+  }
+
+  if (typeof enableNotifications === 'boolean') {
+    return enableNotifications;
+  }
+
+  return Boolean(enableNotifications[notificationStatus]);
+};


### PR DESCRIPTION
This PR allow to disable notifications in notifier for some mutations. This could help in the publication page where some mutations use the notifier and other not... This PR allows to disable notifications completely in the publication page.

This PR also reset the cache for the thumbnails to fix issue in the builder.