### PR TITLE
feat: invalidate publishedInfo on validate feedback

### DIFF
--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -85,10 +85,13 @@ const InvalidateItemOpFeedback = (queryClient: QueryClient) => ({
     queryClient.invalidateQueries(memberKeys.current().recycledItems);
   },
   [FeedBackOperation.VALIDATE]: (itemIds: string[]) => {
-    // todo: invalidate the validation query to refetch the validation status
-    itemIds.map((itemId) =>
-      queryClient.invalidateQueries(itemKeys.single(itemId).validation),
-    );
+    itemIds.forEach((itemId) => {
+      queryClient.invalidateQueries(itemKeys.single(itemId).validation);
+      // TODO: maybe we should invalidates only on success
+      queryClient.invalidateQueries(
+        itemKeys.single(itemId).publishedInformation,
+      );
+    });
   },
 });
 

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -86,7 +86,9 @@ const InvalidateItemOpFeedback = (queryClient: QueryClient) => ({
   },
   [FeedBackOperation.VALIDATE]: (itemIds: string[]) => {
     itemIds.forEach((itemId) => {
-      // invalidate the item content to get the public attribute
+      // Invalidates the item content to get the public attribute.
+      // Without that, the item is still in private (missing the public attribute),
+      // so the frontend can't display the new publication status.
       queryClient.invalidateQueries(itemKeys.single(itemId).content);
       queryClient.invalidateQueries(itemKeys.single(itemId).validation);
       queryClient.invalidateQueries(

--- a/src/ws/hooks/item.ts
+++ b/src/ws/hooks/item.ts
@@ -86,8 +86,9 @@ const InvalidateItemOpFeedback = (queryClient: QueryClient) => ({
   },
   [FeedBackOperation.VALIDATE]: (itemIds: string[]) => {
     itemIds.forEach((itemId) => {
+      // invalidate the item content to get the public attribute
+      queryClient.invalidateQueries(itemKeys.single(itemId).content);
       queryClient.invalidateQueries(itemKeys.single(itemId).validation);
-      // TODO: maybe we should invalidates only on success
       queryClient.invalidateQueries(
         itemKeys.single(itemId).publishedInformation,
       );


### PR DESCRIPTION
Invalidates the item's content and published information to refetch data when validation is done. Its allow to automatically show the published status on the frontend.
