### PR TITLE
fix: fix post item membership

### DIFF
--- a/src/api/membership.ts
+++ b/src/api/membership.ts
@@ -1,7 +1,11 @@
-import { ItemMembership, PermissionLevel, ResultOf, UUID } from '@graasp/sdk';
-import { FAILURE_MESSAGES } from '@graasp/translations';
+import {
+  Account,
+  ItemMembership,
+  PermissionLevel,
+  ResultOf,
+  UUID,
+} from '@graasp/sdk';
 
-import { getMembersByEmail } from '../member/api.js';
 import {
   buildDeleteItemMembershipRoute,
   buildEditItemMembershipRoute,
@@ -43,23 +47,18 @@ export const postManyItemMemberships = async (
 export const postItemMembership = async (
   {
     id,
-    email,
+    accountId,
     permission,
-  }: { id: UUID; email: string; permission: PermissionLevel },
+  }: { id: UUID; accountId: Account['id']; permission: PermissionLevel },
   config: PartialQueryConfigForApi,
 ) => {
   const { API_HOST, axios } = config;
-  const members = await getMembersByEmail({ emails: [email] }, config);
-
-  if (!members || !Object.values(members.data).length) {
-    throw new Error(FAILURE_MESSAGES.MEMBER_NOT_FOUND);
-  }
 
   return verifyAuthentication(() =>
     axios
       .post<ItemMembership>(`${API_HOST}/${buildPostItemMembershipRoute(id)}`, {
         // assume will receive only one member
-        memberId: Object.values(members.data)[0].id,
+        accountId,
         permission,
       })
       .then(({ data }) => data),

--- a/src/mutations/membership.test.ts
+++ b/src/mutations/membership.test.ts
@@ -69,7 +69,7 @@ describe('Membership Mutations', () => {
   describe('usePostItemMembership', () => {
     const mutation = mutations.usePostItemMembership;
 
-    const { email } = MemberFactory();
+    const { id: accountId } = MemberFactory();
 
     it('Create one membership', async () => {
       const route = `/${buildPostItemMembershipRoute(itemId)}`;
@@ -90,11 +90,6 @@ describe('Membership Mutations', () => {
 
       const endpoints = [
         {
-          response: [MemberFactory()],
-          method: HttpMethod.Get,
-          route: `/${buildGetMembersByEmailRoute([email])}`,
-        },
-        {
           response,
           method: HttpMethod.Post,
           route,
@@ -108,7 +103,7 @@ describe('Membership Mutations', () => {
       });
 
       await act(async () => {
-        mockedMutation.mutate({ id: itemId, email, permission });
+        mockedMutation.mutate({ id: itemId, accountId, permission });
         await waitForMutation();
       });
 
@@ -136,11 +131,6 @@ describe('Membership Mutations', () => {
 
       const endpoints = [
         {
-          response: [MemberFactory()],
-          method: HttpMethod.Get,
-          route: `/${buildGetMembersByEmailRoute([email])}`,
-        },
-        {
           response: UNAUTHORIZED_RESPONSE,
           statusCode: StatusCodes.UNAUTHORIZED,
           method: HttpMethod.Post,
@@ -155,7 +145,7 @@ describe('Membership Mutations', () => {
       });
 
       await act(async () => {
-        mockedMutation.mutate({ id: itemId, email, permission });
+        mockedMutation.mutate({ id: itemId, accountId, permission });
         await waitForMutation();
       });
 

--- a/src/mutations/membership.ts
+++ b/src/mutations/membership.ts
@@ -1,4 +1,10 @@
-import { Invitation, ItemMembership, PermissionLevel, UUID } from '@graasp/sdk';
+import {
+  Account,
+  Invitation,
+  ItemMembership,
+  PermissionLevel,
+  UUID,
+} from '@graasp/sdk';
 import { SUCCESS_MESSAGES } from '@graasp/translations';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -20,8 +26,11 @@ export default (queryConfig: QueryClientConfig) => {
   const usePostItemMembership = () => {
     const queryClient = useQueryClient();
     return useMutation(
-      (payload: { id: UUID; email: string; permission: PermissionLevel }) =>
-        Api.postItemMembership(payload, queryConfig),
+      (payload: {
+        id: UUID;
+        accountId: Account['id'];
+        permission: PermissionLevel;
+      }) => Api.postItemMembership(payload, queryConfig),
       {
         onSuccess: () => {
           notifier?.({


### PR DESCRIPTION
The post item membership is used only when upgrading a membership in a child. 
So I also took the opportunity to remove the email search and directly provide the member id since we always have it. If not, we can use `shareItem` does deal for us with the email.

fix #902 