### PR TITLE
fix: decode exported filename

### DIFF
--- a/src/api/itemExport.test.ts
+++ b/src/api/itemExport.test.ts
@@ -1,0 +1,30 @@
+import nock from 'nock';
+import { v4 } from 'uuid';
+import { describe, expect, it } from 'vitest';
+
+import { API_HOST } from '../../test/constants.js';
+import { buildExportItemRoute } from '../routes.js';
+import configureAxios from './axios.js';
+import { exportItem } from './itemExport.js';
+
+describe('itemExport', () => {
+  it('decodes the download name', async () => {
+    const id = v4();
+    const name = 'hello my àle';
+    const axiosInstance = configureAxios();
+    nock(API_HOST)
+      .get(`/${buildExportItemRoute(id)}`)
+      .reply(
+        200,
+        {},
+        { 'content-disposition': `filename="${encodeURI(name)}"` },
+      );
+
+    const { name: decodedName } = await exportItem(id, {
+      API_HOST,
+      axios: axiosInstance,
+    });
+
+    expect(decodedName).toEqual(name);
+  });
+});

--- a/src/api/itemExport.ts
+++ b/src/api/itemExport.ts
@@ -13,8 +13,9 @@ export const exportItem = async (
       responseType: 'blob',
     })
     .then(({ data, headers }) => {
-      const name =
+      const [_, encodedFileName] =
         // content is usually: filename="name.png"
-        headers['content-disposition']?.split('"')?.[1] ?? 'export-file';
+        headers['content-disposition'].split('"');
+      const name = decodeURI(encodedFileName);
       return { name, data };
     });


### PR DESCRIPTION
This has been tested in builder and works as expected with filename containing emojis for example.

fix #918 