### PR TITLE
fix: public profile should be null when NO_CONTENT

### DIFF
--- a/src/member/publicProfile/api.ts
+++ b/src/member/publicProfile/api.ts
@@ -1,5 +1,7 @@
 import { PublicProfile, UUID } from '@graasp/sdk';
 
+import { StatusCodes } from 'http-status-codes';
+
 import { PartialQueryConfigForApi } from '../../types.js';
 import {
   buildGetOwnPublicProfileRoute,
@@ -11,7 +13,13 @@ import {
 export const getOwnProfile = ({ API_HOST, axios }: PartialQueryConfigForApi) =>
   axios
     .get<PublicProfile | null>(`${API_HOST}/${buildGetOwnPublicProfileRoute()}`)
-    .then(({ data }) => data);
+    .then(({ status, data }) => {
+      if (status === StatusCodes.NO_CONTENT) {
+        return null;
+      } else {
+        return data;
+      }
+    });
 
 export const getPublicProfile = (
   memberId: UUID,
@@ -21,7 +29,13 @@ export const getPublicProfile = (
     .get<PublicProfile | null>(
       `${API_HOST}/${buildGetPublicProfileRoute(memberId)}`,
     )
-    .then(({ data }) => data);
+    .then(({ status, data }) => {
+      if (status === StatusCodes.NO_CONTENT) {
+        return null;
+      } else {
+        return data;
+      }
+    });
 
 export type PostPublicProfilePayloadType = {
   bio: string;

--- a/src/member/publicProfile/hooks.test.ts
+++ b/src/member/publicProfile/hooks.test.ts
@@ -27,7 +27,7 @@ describe('Public Profile Hooks', () => {
     const response = MEMBER_PUBLIC_PROFILE;
 
     const hook = () => hooks.useOwnProfile();
-    it(`Receive actions for item id`, async () => {
+    it('Receive own profile', async () => {
       const endpoints = [{ route, response }];
       const { data } = await mockHook({ endpoints, hook, wrapper });
       expect(data).toEqual(response);
@@ -36,7 +36,21 @@ describe('Public Profile Hooks', () => {
       );
     });
 
-    it(`Unauthorized`, async () => {
+    it('Own profile does not exist, data should be null', async () => {
+      const endpoints = [
+        {
+          route,
+          // set a string on the response to see if it will be set in the query client: it should not, the key value should be "null"
+          response: 'toto',
+          statusCode: StatusCodes.NO_CONTENT,
+        },
+      ];
+      const { data } = await mockHook({ endpoints, hook, wrapper });
+      expect(data).toBeNull();
+      expect(queryClient.getQueryData(memberKeys.current().profile)).toBeNull();
+    });
+
+    it('Unauthorized', async () => {
       const endpoints = [
         {
           route,
@@ -60,15 +74,16 @@ describe('Public Profile Hooks', () => {
   describe('usePublicProfile', () => {
     const id = 'member-id';
     const response = MEMBER_PUBLIC_PROFILE;
+    const route = `/${buildGetPublicProfileRoute(id)}`;
+    const hook = () => hooks.usePublicProfile(id);
 
     it(`Receive member public profile for member-id = ${id}`, async () => {
       const endpoints = [
         {
-          route: `/${buildGetPublicProfileRoute(id)}`,
+          route,
           response,
         },
       ];
-      const hook = () => hooks.usePublicProfile(id);
       const { data } = await mockHook({
         hook,
         wrapper,
@@ -78,6 +93,23 @@ describe('Public Profile Hooks', () => {
         response,
       );
       expect(data).toMatchObject(response);
+    });
+
+    it('Member profile does not exist, data should be null', async () => {
+      const endpoints = [
+        {
+          route,
+          // set a string on the response to see if it will be set in the query client: it should not, the key value should be "null"
+          response: 'toto',
+          statusCode: StatusCodes.NO_CONTENT,
+        },
+      ];
+
+      const { data } = await mockHook({ endpoints, hook, wrapper });
+      expect(data).toBeNull();
+      expect(
+        queryClient.getQueryData(memberKeys.single(id).profile),
+      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
In this PR I fix an issue related to the data that is returned by react-query when getting a public profile of a own profile that does not exist. 

Currently, when we ask for the user's own profile or a member public profile and they do not exist yet, the backend return a 204 NO_CONTENT response. This results in a `data` property in axios that is actually an empty string `''`.

Instead we expect to have a `null` value to be stored in the query cache.

The null value is necessary in order to discriminate between the query being fetched (`undefined`) and the data not being available on the server `null`.

### How it was fixed

In order to fix this issue, I added a check for the statusCode of the response and if it is 204, I return `null`

This was done to the `ownProfile` as well as the `memberProfile` (any member). 

Tests were added to ensure this behaviour is guaranteed.

### Thoughts

Seeing as `axios` is handling missing responses with empty strings, I am not sure that our approach is right. Semantically I prefer the data to be `null` than `empty string` when the profile does not exist, however having to manually deal with it, is cumbersome and error-prone. On the other side, I am not sure that returning an error code would necessarily be better... To be discussed if we think this needs to be changed in the future, for now this fix should do. 